### PR TITLE
[FEAT] : Navigate to top via button for mobile version added

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import 'react-toastify/ReactToastify.css';
 import NavBar from "./components/NavBar";
 import Footer from "./components/Footer.jsx";
 import Loader from "./components/Loader";
+import ScrollToTopButton from "./components/ScrollToTopButton.jsx";
 
 // Lazy loaded components
 const Home = lazy(() => import("./pages/Home"));
@@ -81,6 +82,7 @@ function App() {
               </Routes>
             </Suspense>
           </main>
+          <ScrollToTopButton />
           <Footer />
         </div>
       </LoadingProvider>

--- a/client/src/components/ScrollToTopButton.jsx
+++ b/client/src/components/ScrollToTopButton.jsx
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from "react";
+import { FiArrowUp } from 'react-icons/fi';
+
+function ScrollToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    let ticking = false;
+
+    const handleScroll = () => {
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          setIsVisible(window.scrollY > 300);
+          ticking = false;
+        });
+        ticking = true;
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  const handleClick = useCallback(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, []);
+
+  return (
+    <button
+      type="button"
+      aria-label="Scroll to top"
+      onClick={handleClick}
+      className={`md:hidden fixed z-50 right-5 bottom-[75px] rounded-full bg-primary text-white shadow-card hover:shadow-card-hover transition-opacity duration-300 focus:outline-none focus:ring-2 focus:ring-primary-300 dark:focus:ring-primary-700 ${isVisible ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+    >
+      <span className="h-12 w-12 grid place-items-center">
+        <FiArrowUp className="text-2xl font-bold"/>
+      </span>
+    </button>
+  );
+}
+
+export default ScrollToTopButton;
+
+


### PR DESCRIPTION
---
name: "📦 Pull Request"
about: Feature Added to Navigate to Top via button for mobile verison
labels: "gssoc 25 | level 1"
---

## 📌 Linked Issue
- [x] Connected to #14 
---

## 🛠 Changes Made
- Added: Button For Navigation (/components/ScrollToTop.jsx)
- Fixed: Navigation To Top Via Button in Mobile Version
- Updated: App.jsx & Added a new file in /components/ScrollToTop.jsx
---
## 📸 UI Changes (if applicable)
| Before | After |
|--------|-------|
| <img width="337" height="729" alt="Screenshot 2025-08-21 at 4 28 55 PM" src="https://github.com/user-attachments/assets/a86d9600-42fe-472d-9ccf-cb8914d69171" /> | <img width="339" height="730" alt="Screenshot 2025-08-21 at 4 27 41 PM" src="https://github.com/user-attachments/assets/1f980c5a-7101-4507-8ec2-d55da3d08ef2" /> |

Demo Video : https://drive.google.com/file/d/1xjkZ187cwcKjFMijnQ3qUwObfN-eH7vR/view?usp=sharing
---

## ✅ Checklist
- [x] Created a new branch for PR
- [x] Have stared the repository
- [x] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [x] No console warnings/errors
- [x] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)