### PR TITLE
Todo closing fix

### DIFF
--- a/client/src/components/TodoList.jsx
+++ b/client/src/components/TodoList.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { CheckCircle, Circle, Plus, Trash2, ListTodo } from "lucide-react";
 import { usePopup } from "../context/PopupContext";
 import { useAuth } from "../store/auth";
@@ -10,6 +10,8 @@ export default function TodoList() {
   const [newTodo, setNewTodo] = useState("");
   const [open, setOpen] = useState(false); // widget toggle state
 
+  const widgetRef = useRef(null);
+
   const handleAdd = () => {
     if (!isLoggedIn) return;
     if (newTodo.trim()) {
@@ -20,6 +22,23 @@ export default function TodoList() {
 
   // Ensure todos is always an array
   const todoList = Array.isArray(todos) ? todos : [];
+
+  // 🔹 Close widget if clicked outside
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (widgetRef.current && !widgetRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [open]);
 
   return (
     <>
@@ -45,6 +64,7 @@ export default function TodoList() {
             exit={{ opacity: 0, scale: 0.8, y: 40 }}
             transition={{ duration: 0.35, ease: "easeOut" }}
             className="fixed bottom-28 left-4 z-50 w-80 max-w-full"
+            ref={widgetRef} // 🔹 reference for outside click detection
           >
             <motion.div
               layout
@@ -60,8 +80,7 @@ export default function TodoList() {
                 Todo List
                 <span className="text-sm text-gray-600 dark:text-dark-text-secondary flex items-center gap-2">
                   <CheckCircle className="text-success" />{" "}
-                  {todoList.filter((t) => t.completed).length} /{" "}
-                  {todoList.length}
+                  {todoList.filter((t) => t.completed).length} / {todoList.length}
                 </span>
               </motion.h2>
 
@@ -101,9 +120,7 @@ export default function TodoList() {
                       >
                         <button
                           disabled={!isLoggedIn}
-                          onClick={() =>
-                            toggleTodoItem(todo._id || todo.id)
-                          }
+                          onClick={() => toggleTodoItem(todo._id || todo.id)}
                         >
                           {todo.completed ? (
                             <CheckCircle className="text-success" />

--- a/server/controllers/todoController.js
+++ b/server/controllers/todoController.js
@@ -14,7 +14,7 @@ const getTodos = async (req, res) => {
 const addTodo = async (req, res) => {
   try {
     const newTodo = new Todo({
-      user: req.user?.id ,
+      user: req.user.id,
       text: req.body.text,
       completed: false,
     });

--- a/server/routes/TodoRoute.js
+++ b/server/routes/TodoRoute.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { getTodos, addTodo, toggleTodo, deleteTodo } from "../controllers/TodoController.js";
+import { getTodos, addTodo, toggleTodo, deleteTodo } from "../controllers/todoController.js";
  import authMiddleware from "../middlewares/authMiddleware.js";
 
 const router = express.Router();


### PR DESCRIPTION
---
name: "📦 Pull Request"
about: Submit changes for review
title: "PR: Add outside click-to-close feature in TodoList widget"
labels: "enhancement"
assignees: ""
---

## 📌 Linked Issue
<!-- Link to the issue this PR addresses -->
- [x] Connected to #issue_number
---

## 🛠 Changes Made
- Added: Feature to close the **TodoList widget when clicking outside** of it.
- Updated: `TodoList` component to use `useRef` + `useEffect` for outside click detection.
- Updated: Improved UX by keeping animations smooth with `framer-motion`.

---
## 🧪 Testing
- [x] Ran unit tests (`npm test`)
- [x] Tested manually:
  - Test case 1: Open Todo widget → click outside → widget closes ✅
  - Test case 2: Open Todo widget → click inside (input or task) → widget stays open ✅
  - Test case 3: Add new todo while widget is open → works as expected ✅

---
## 📸 UI Changes
| Before | After |
|--------|-------|
| Widget stays open until explicitly closed | Widget closes automatically when user clicks outside |

---
## 📝 Documentation Updates
- [ ] Updated README/docs
- [x] Added code comments in `TodoList` for outside click handler.

---
## ✅ Checklist
- [x] Created a new branch for PR
- [x] Have starred the repository
- [x] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [x] No console warnings/errors
- [x] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)

## 💡 Additional Notes
- Enhancement improves UX for users managing todos.  
- No breaking changes introduced.  
