### PR TITLE
Added Copy Code Functionality to Code Blocks & Loader Overlay/Inline Toggle

### DIFF
--- a/client/src/components/Loader.jsx
+++ b/client/src/components/Loader.jsx
@@ -1,12 +1,12 @@
 
 import { useTheme } from '../context/ThemeContext';
 
-function Loader() {
+function Loader({ asOverlay = true }) {
   const { theme } = useTheme();
   const isDark = theme === 'dark';
 
   return (
-    <div className={`fixed inset-0 flex flex-col items-center justify-center z-[9999] ${isDark ? 'bg-black/90' : 'bg-light-bg-primary/80'} backdrop-blur-sm`}>
+    <div className={`${asOverlay ? 'inset-0 fixed' : 'py-24'} flex flex-col items-center justify-center z-[9999] ${isDark ? 'bg-black/90' : 'bg-light-bg-primary/80'} backdrop-blur-sm`}>
       {/* Animated Books Stack */}
       <div className="relative w-32 h-32 mb-6">
         <div className="absolute inset-0 flex items-end justify-center">
@@ -14,7 +14,7 @@ function Loader() {
           <div className="w-8 h-20 bg-primary/80 rounded-t-sm transform rotate-6 animate-pulse animation-delay-200 ml-2"></div>
           <div className="w-8 h-18 bg-primary/60 rounded-t-sm transform -rotate-3 animate-pulse animation-delay-400 ml-2"></div>
         </div>
-        
+
         {/* Floating Knowledge Particles */}
         <div className="absolute top-0 left-0 w-2 h-2 bg-primary rounded-full animate-float animation-delay-100"></div>
         <div className="absolute top-4 right-2 w-1.5 h-1.5 bg-primary/70 rounded-full animate-float animation-delay-300"></div>
@@ -46,7 +46,7 @@ function Loader() {
       <div className="absolute top-1/4 left-1/4 transform -translate-x-1/2 -translate-y-1/2">
         <div className={`w-6 h-6 ${isDark ? 'text-primary' : 'text-primary/30'} animate-spin-slow`}>
           <svg fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 2C13.1 2 14 2.9 14 4V6.28C14.6 6.54 15.17 6.86 15.69 7.25L17.41 5.53C18.2 4.74 19.46 4.74 20.25 5.53C21.04 6.32 21.04 7.58 20.25 8.37L18.53 10.09C18.92 10.61 19.24 11.18 19.5 11.78H22C23.1 11.78 24 12.68 24 13.78S23.1 15.78 22 15.78H19.72C19.46 16.38 19.14 16.95 18.75 17.47L20.47 19.19C21.26 19.98 21.26 21.24 20.47 22.03C19.68 22.82 18.42 22.82 17.63 22.03L15.91 20.31C15.39 20.7 14.82 21.02 14.22 21.28V24C14.22 25.1 13.32 26 12.22 26S10.22 25.1 10.22 24V21.72C9.62 21.46 9.05 21.14 8.53 20.75L6.81 22.47C6.02 23.26 4.76 23.26 3.97 22.47C3.18 21.68 3.18 20.42 3.97 19.63L5.69 17.91C5.3 17.39 4.98 16.82 4.72 16.22H2C0.9 16.22 0 15.32 0 14.22S0.9 12.22 2 12.22H4.28C4.54 11.62 4.86 11.05 5.25 10.53L3.53 8.81C2.74 8.02 2.74 6.76 3.53 5.97C4.32 5.18 5.58 5.18 6.37 5.97L8.09 7.69C8.61 7.3 9.18 6.98 9.78 6.72V4C9.78 2.9 10.68 2 11.78 2H12Z"/>
+            <path d="M12 2C13.1 2 14 2.9 14 4V6.28C14.6 6.54 15.17 6.86 15.69 7.25L17.41 5.53C18.2 4.74 19.46 4.74 20.25 5.53C21.04 6.32 21.04 7.58 20.25 8.37L18.53 10.09C18.92 10.61 19.24 11.18 19.5 11.78H22C23.1 11.78 24 12.68 24 13.78S23.1 15.78 22 15.78H19.72C19.46 16.38 19.14 16.95 18.75 17.47L20.47 19.19C21.26 19.98 21.26 21.24 20.47 22.03C19.68 22.82 18.42 22.82 17.63 22.03L15.91 20.31C15.39 20.7 14.82 21.02 14.22 21.28V24C14.22 25.1 13.32 26 12.22 26S10.22 25.1 10.22 24V21.72C9.62 21.46 9.05 21.14 8.53 20.75L6.81 22.47C6.02 23.26 4.76 23.26 3.97 22.47C3.18 21.68 3.18 20.42 3.97 19.63L5.69 17.91C5.3 17.39 4.98 16.82 4.72 16.22H2C0.9 16.22 0 15.32 0 14.22S0.9 12.22 2 12.22H4.28C4.54 11.62 4.86 11.05 5.25 10.53L3.53 8.81C2.74 8.02 2.74 6.76 3.53 5.97C4.32 5.18 5.58 5.18 6.37 5.97L8.09 7.69C8.61 7.3 9.18 6.98 9.78 6.72V4C9.78 2.9 10.68 2 11.78 2H12Z" />
           </svg>
         </div>
       </div>
@@ -54,7 +54,7 @@ function Loader() {
       <div className="absolute top-3/4 right-1/4 transform translate-x-1/2 translate-y-1/2">
         <div className={`w-5 h-5 ${isDark ? 'text-primary' : 'text-primary/40'} animate-bounce animation-delay-800`}>
           <svg fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12,3L1,9L12,15L21,10.09V17H23V9M5,13.18V17.18L12,21L19,17.18V13.18L12,17L5,13.18Z"/>
+            <path d="M12,3L1,9L12,15L21,10.09V17H23V9M5,13.18V17.18L12,21L19,17.18V13.18L12,17L5,13.18Z" />
           </svg>
         </div>
       </div>
@@ -62,7 +62,7 @@ function Loader() {
       <div className="absolute bottom-1/4 left-1/3 transform -translate-x-1/2 translate-y-1/2">
         <div className={`w-4 h-4 ${isDark ? 'text-primary' : 'text-primary/25'} animate-pulse animation-delay-1000`}>
           <svg fill="currentColor" viewBox="0 0 24 24">
-            <path d="M17.5,12A1.5,1.5 0 0,1 16,10.5A1.5,1.5 0 0,1 17.5,9A1.5,1.5 0 0,1 19,10.5A1.5,1.5 0 0,1 17.5,12M14.5,8A1.5,1.5 0 0,1 13,6.5A1.5,1.5 0 0,1 14.5,5A1.5,1.5 0 0,1 16,6.5A1.5,1.5 0 0,1 14.5,8M9.5,8A1.5,1.5 0 0,1 8,6.5A1.5,1.5 0 0,1 9.5,5A1.5,1.5 0 0,1 11,6.5A1.5,1.5 0 0,1 9.5,8M6.5,12A1.5,1.5 0 0,1 5,10.5A1.5,1.5 0 0,1 6.5,9A1.5,1.5 0 0,1 8,10.5A1.5,1.5 0 0,1 6.5,12M12,3A9,9 0 0,0 3,12A9,9 0 0,0 12,21A8.98,8.98 0 0,0 21,12A9,9 0 0,0 12,3Z"/>
+            <path d="M17.5,12A1.5,1.5 0 0,1 16,10.5A1.5,1.5 0 0,1 17.5,9A1.5,1.5 0 0,1 19,10.5A1.5,1.5 0 0,1 17.5,12M14.5,8A1.5,1.5 0 0,1 13,6.5A1.5,1.5 0 0,1 14.5,5A1.5,1.5 0 0,1 16,6.5A1.5,1.5 0 0,1 14.5,8M9.5,8A1.5,1.5 0 0,1 8,6.5A1.5,1.5 0 0,1 9.5,5A1.5,1.5 0 0,1 11,6.5A1.5,1.5 0 0,1 9.5,8M6.5,12A1.5,1.5 0 0,1 5,10.5A1.5,1.5 0 0,1 6.5,9A1.5,1.5 0 0,1 8,10.5A1.5,1.5 0 0,1 6.5,12M12,3A9,9 0 0,0 3,12A9,9 0 0,0 12,21A8.98,8.98 0 0,0 21,12A9,9 0 0,0 12,3Z" />
           </svg>
         </div>
       </div>

--- a/client/src/pages/Notes/JavaScriptFundamentals/JavaScriptFundamentals.jsx
+++ b/client/src/pages/Notes/JavaScriptFundamentals/JavaScriptFundamentals.jsx
@@ -76,7 +76,7 @@ const JavaScriptFundamentals = () => {
 
           {/* ROUTES OF THE SUB NOTES */}
           <div className="p-4 md:p-8">
-            <React.Suspense fallback={<Loader />}>
+            <React.Suspense fallback={<Loader asOverlay={false} />}>
               <Routes>
                 <Route index element={<JsHeroPage />} />
 

--- a/client/src/pages/Notes/JavaScriptFundamentals/components/CodeBlock.jsx
+++ b/client/src/pages/Notes/JavaScriptFundamentals/components/CodeBlock.jsx
@@ -1,40 +1,73 @@
+import { useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import { Copy, Check } from 'lucide-react';
 
 const CodeBlock = ({ code }) => {
-    return (
-        <div className="my-4 overflow-x-auto text-sm sm:text-base">
-            <SyntaxHighlighter
-                language="javascript"
-                style={vscDarkPlus}
-                customStyle={{
-                    margin: 0,
-                    padding: '1.25rem',
-                    borderRadius: '0.5rem',
-                    background: '#1e1e1e',
-                    fontSize: '0.875rem',
-                    lineHeight: '1.5',
-                }}
-                wrapLines={true}
-                wrapLongLines={true}
-                codeTagProps={{
-                    style: {
-                        fontFamily: 'Fira Code, monospace',
-                        wordBreak: 'break-word',
-                        whiteSpace: 'pre-wrap',
-                    },
-                }}
-                lineProps={{
-                    style: {
-                        wordBreak: 'break-word',
-                        whiteSpace: 'pre-wrap',
-                    },
-                }}
-            >
-                {code}
-            </SyntaxHighlighter>
-        </div>
-    )
-}
+    const [copied, setCopied] = useState(false);
 
-export default CodeBlock
+    const copyToClipboard = () => {
+        navigator.clipboard.writeText(code).then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        });
+    };
+
+    return (
+        <div className="my-4 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
+            <div className="relative">
+                <button
+                    onClick={copyToClipboard}
+                    className="absolute right-2 top-2 z-10 flex items-center gap-1 rounded-md bg-gray-800/80 px-2 py-1 text-xs text-gray-200 transition-colors hover:bg-gray-700/90"
+                    title="Copy to clipboard"
+                >
+                    {copied ? (
+                        <>
+                            <Check size={14} />
+                            <span>Copied!</span>
+                        </>
+                    ) : (
+                        <>
+                            <Copy size={14} />
+                            <span>Copy</span>
+                        </>
+                    )}
+                </button>
+                <div className="overflow-x-auto text-sm sm:text-base">
+                    <SyntaxHighlighter
+                        language="javascript"
+                        style={vscDarkPlus}
+                        customStyle={{
+                            margin: 0,
+                            padding: '1.25rem',
+                            background: '#1e1e1e',
+                            fontSize: '0.875rem',
+                            lineHeight: '1.5',
+                            borderTopLeftRadius: '0.375rem',
+                            borderTopRightRadius: '0.375rem',
+                        }}
+                        wrapLines={true}
+                        wrapLongLines={true}
+                        codeTagProps={{
+                            style: {
+                                fontFamily: 'Fira Code, monospace',
+                                wordBreak: 'break-word',
+                                whiteSpace: 'pre-wrap',
+                            },
+                        }}
+                        lineProps={{
+                            style: {
+                                wordBreak: 'break-word',
+                                whiteSpace: 'pre-wrap',
+                            },
+                        }}
+                    >
+                        {code}
+                    </SyntaxHighlighter>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default CodeBlock;


### PR DESCRIPTION
**Hi team 👋**

This PR enhances user experience by adding copy-to-clipboard functionality to every code block across the docs. Additionally, it introduces a new `asOverlay` boolean prop to the Loader component to toggle between overlay and inline display styles.

---

### 🔍 Problem Resolved

- Users previously couldn’t easily copy code snippets; copying required manual selection.
- Loader component was limited to a fixed full-screen overlay, restricting flexible usage in different layout contexts.

---

### ✅ What’s Changed

- Implemented a copy button for every code block, allowing users to quickly copy code with a single click.
- Added visual feedback (e.g., “Copied!” message) upon successful copy action.
- Enhanced the Loader component by adding the `asOverlay` prop:
  - When `true` (default), loader behaves as a full-screen fixed overlay.
  - When `false`, loader renders inline as a block occupying its parent container.
- This enables more adaptable loading states in various UI sections.

---

### 📸 Screenshot

**`asOverlay` is false**
<img width="1908" height="1103" alt="image" src="https://github.com/user-attachments/assets/167303ee-775a-47da-8327-57d9ed87c7ec" />

**`asOverlay` is true**
<img width="1910" height="1101" alt="image" src="https://github.com/user-attachments/assets/7d0e7d4d-11af-4e7d-8e40-d87a10e7a049" />

**Added Copy Code Button**
<img width="1438" height="455" alt="image" src="https://github.com/user-attachments/assets/ec967840-f279-4281-954b-08b7fbfb26d9" />


---

### 🎯 Result

- Users can now copy any code snippet with one click, improving documentation usability.
- Loader can be used flexibly as an overlay or inline element based on context, enhancing UI design consistency.

---

### 🏷 Labels Requested

* `gssoc25`
* `frontend`
* `level3`

---
