### PR TITLE
Added OOPS Topic Routes & Dynamic Title Component 

### DIFF
--- a/client/src/pages/Notes/JavaScriptFundamentals/JavaScriptFundamentals.jsx
+++ b/client/src/pages/Notes/JavaScriptFundamentals/JavaScriptFundamentals.jsx
@@ -35,7 +35,7 @@ const LoopsWithArrays = React.lazy(() => import('./JsTopics/JsObjects/LoopsWithA
 const MapFilterAndReduce = React.lazy(() => import('./JsTopics/JsObjects/MapFilterReduce'));
 const DateInJs = React.lazy(() => import('./JsTopics/JsObjects/DateInJS'));
 const MathInJs = React.lazy(() => import('./JsTopics/JsObjects/MathInJS'));
-const NumberinJs = React.lazy(() => import('./JsTopics/JsObjects/NumberInJS'));
+const NumberInJs = React.lazy(() => import('./JsTopics/JsObjects/NumberInJS'));
 const BooleanInJs = React.lazy(() => import('./JsTopics/JsObjects/BooleanInJS'));
 
 // JavaScript DOM and BOM
@@ -50,6 +50,16 @@ const JsGetElementsByName = React.lazy(() => import('./JsTopics/Dom_Bom/JsGetEle
 const JsGetElementsByTagName = React.lazy(() => import('./JsTopics/Dom_Bom/JsGetElementsByTagName'));
 const JsInnerHTML = React.lazy(() => import('./JsTopics/Dom_Bom/JsInnerHTML'));
 const JsOuterHTML = React.lazy(() => import('./JsTopics/Dom_Bom/JsOuterHTML'));
+
+// JavaScript DOM and BOM
+const JsClass = React.lazy(() => import('./JsTopics/Oops/JsClass'));
+const JsObjects = React.lazy(() => import('./JsTopics/Oops/JsObjects'));
+const JsStaticMethod = React.lazy(() => import('./JsTopics/Oops/JsStaticMethod'));
+const JsConstructor = React.lazy(() => import('./JsTopics/Oops/JsConstructor'));
+const JsEncapsulation = React.lazy(() => import('./JsTopics/Oops/JsEncapsulation'));
+const JsInheritance = React.lazy(() => import('./JsTopics/Oops/JsInheritance'));
+const JsPolymorphism = React.lazy(() => import('./JsTopics/Oops/JsPolymorphism'));
+const JsAbstraction = React.lazy(() => import('./JsTopics/Oops/JsAbstraction'));
 
 
 // Lazy load the note components --------------------------------------
@@ -136,7 +146,7 @@ const JavaScriptFundamentals = () => {
                 <Route path="map-filter-reduce" element={<MapFilterAndReduce />} />
                 <Route path="date" element={<DateInJs />} />
                 <Route path="math" element={<MathInJs />} />
-                <Route path="number" element={<NumberinJs />} />
+                <Route path="number" element={<NumberInJs />} />
                 <Route path="boolean" element={<BooleanInJs />} />
 
                 {/* DOM and BOM */}
@@ -152,11 +162,16 @@ const JavaScriptFundamentals = () => {
                 <Route path="innerHTML" element={<JsInnerHTML />} />
                 <Route path="outerHTML" element={<JsOuterHTML />} />
 
-
-
-
-
                 {/* OOPS */}
+                <Route path="class" element={<JsClass />} />
+                <Route path="objects" element={<JsObjects />} />
+                <Route path="static-method" element={<JsStaticMethod />} />
+                <Route path="constructor" element={<JsConstructor />} />
+                <Route path="encapsulation" element={<JsEncapsulation />} />
+                <Route path="inheritance" element={<JsInheritance />} />
+                <Route path="polymorphism" element={<JsPolymorphism />} />
+                <Route path="abstraction" element={<JsAbstraction />} />
+
 
               </Routes>
             </React.Suspense>

--- a/client/src/pages/Notes/JavaScriptFundamentals/JavaScriptFundamentals.jsx
+++ b/client/src/pages/Notes/JavaScriptFundamentals/JavaScriptFundamentals.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { Routes, Route, useLocation, Outlet } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
 import JavaScriptNotesSidebar from './components/JavaScriptNotesSideBar';
 import JsHeroPage from './components/JsHeroPage';
 import Loader from '../../../components/Loader';
 import Breadcrumb from '../../../components/Breadcrumb';
 import useMobile from '../../../hooks/useMobile';
+import JsPageTitleManager from './components/JsPageTitleManager';
 
 // Lazy load the note components --------------------------------------
 // Introduction
@@ -112,6 +113,9 @@ const JavaScriptFundamentals = () => {
           {/* Breadcrumb */}
           <Breadcrumb isSidebarOpen={isSidebarOpen} toggleSidebar={toggleSidebar} className={"p-4"} />
 
+          {/* Page Title Manager */}
+          <JsPageTitleManager />
+
           {/* ROUTES OF THE SUB NOTES */}
           <div className="p-4 md:p-8">
             <React.Suspense fallback={<Loader />}>
@@ -119,8 +123,8 @@ const JavaScriptFundamentals = () => {
                 <Route index element={<JsHeroPage />} />
 
                 {/* Introduction */}
-                <Route path="js-introduction" element={<JsIntroduction />} />
-                <Route path="js-execution" element={<JsExecution />} />
+                <Route path="introduction" element={<JsIntroduction />} />
+                <Route path="execution" element={<JsExecution />} />
                 <Route path="node.js-installation" element={<NodeJsInstallation />} />
 
                 {/* Javascript variables */}

--- a/client/src/pages/Notes/JavaScriptFundamentals/components/JsPageTitleManager.jsx
+++ b/client/src/pages/Notes/JavaScriptFundamentals/components/JsPageTitleManager.jsx
@@ -1,0 +1,76 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const jsRoutesAndTitles = {
+    // Js Home Page
+    "/notes/javascript": "Master JavaScript Fundamentals | Codify",
+
+
+    "/notes/javascript/introduction": "JavaScript Introduction | Codify",
+    "/notes/javascript/execution": "How JavaScript Executes | Codify",
+    "/notes/javascript/node.js-installation": "Installing Node.js | Codify",
+
+    // Javascript variables
+    "/notes/javascript/what-are-variables": "What are Variables in JavaScript? | Codify",
+    "/notes/javascript/variable-naming-rules": "JavaScript Variable Naming Rules | Codify",
+    "/notes/javascript/primitives-and-objects": "Primitives vs Objects in JavaScript | Codify",
+    "/notes/javascript/operators-and-expressions": "Operators and Expressions in JavaScript | Codify",
+    "/notes/javascript/var-vs-let-vs-const": "var vs let vs const in JavaScript | Codify",
+
+    // Javascript basics
+    "/notes/javascript/if-else-conditionals": "If-Else Conditionals in JavaScript | Codify",
+    "/notes/javascript/if-else-ladder": "If-Else Ladder in JavaScript | Codify",
+    "/notes/javascript/switch-case": "Switch Case in JavaScript | Codify",
+    "/notes/javascript/ternary-operator": "Ternary Operator in JavaScript | Codify",
+    "/notes/javascript/for-loops": "For Loops in JavaScript | Codify",
+    "/notes/javascript/while-loops": "While Loops in JavaScript | Codify",
+    "/notes/javascript/functions": "Functions in JavaScript | Codify",
+
+    // Javascript objects
+    "/notes/javascript/strings": "JavaScript Strings | Codify",
+    "/notes/javascript/arrays-and-array-methods": "JavaScript Arrays and Methods | Codify",
+    "/notes/javascript/loops-with-arrays": "Looping Through Arrays in JavaScript | Codify",
+    "/notes/javascript/map-filter-reduce": "Map, Filter, Reduce in JavaScript | Codify",
+    "/notes/javascript/date": "JavaScript Date Object | Codify",
+    "/notes/javascript/math": "JavaScript Math Object | Codify",
+    "/notes/javascript/number": "JavaScript Numbers | Codify",
+    "/notes/javascript/boolean": "JavaScript Booleans | Codify",
+
+    // DOM and BOM
+    "/notes/javascript/window-object": "JavaScript Window Object | Codify",
+    "/notes/javascript/history-object": "JavaScript History Object | Codify",
+    "/notes/javascript/navigator-object": "JavaScript Navigator Object | Codify",
+    "/notes/javascript/screen-object": "JavaScript Screen Object | Codify",
+    "/notes/javascript/document-object": "JavaScript Document Object | Codify",
+    "/notes/javascript/getelementbyid": "JavaScript getElementById() | Codify",
+    "/notes/javascript/getelementsbyclassname": "JavaScript getElementsByClassName() | Codify",
+    "/notes/javascript/getelementsbyname": "JavaScript getElementsByName() | Codify",
+    "/notes/javascript/getelementsbytagname": "JavaScript getElementsByTagName() | Codify",
+    "/notes/javascript/innerhtml": "JavaScript innerHTML | Codify",
+    "/notes/javascript/outerhtml": "JavaScript outerHTML | Codify",
+
+    // OOPS
+    "/notes/javascript/class": "JavaScript Classes | Codify",
+    "/notes/javascript/objects": "Working with Objects in JavaScript | Codify",
+    "/notes/javascript/static-method": "Static Methods in JavaScript | Codify",
+    "/notes/javascript/constructor": "JavaScript Constructor | Codify",
+    "/notes/javascript/encapsulation": "Encapsulation in JavaScript | Codify",
+    "/notes/javascript/inheritance": "Inheritance in JavaScript | Codify",
+    "/notes/javascript/polymorphism": "Polymorphism in JavaScript | Codify",
+    "/notes/javascript/abstraction": "Abstraction in JavaScript | Codify",
+};
+
+
+const PageTitleManager = () => {
+    const location = useLocation();
+
+    useEffect(() => {
+        console.log(location.pathname)
+        const pageTitle = jsRoutesAndTitles[location.pathname] || "Codify";
+        document.title = pageTitle;
+    }, [location]);
+
+    return null;
+};
+
+export default PageTitleManager;

--- a/client/src/pages/Notes/JavaScriptFundamentals/components/JsSideBarData.json
+++ b/client/src/pages/Notes/JavaScriptFundamentals/components/JsSideBarData.json
@@ -1,5 +1,5 @@
 {
-    "Introduction": ["Js Introduction", "JS execution", "Node.js Installation"],
+    "Introduction": ["Introduction", "Execution", "Node.js Installation"],
     "JavaScript Variables": [
         "What are Variables?",
         "Variable Naming Rules",


### PR DESCRIPTION
**Hi team 👋**

This PR introduces explicit routing for every core OOPS topic in the JavaScript docs and adds a new `JsPageTitleManager` component for real-time page title updates based on active route.

---

### 🔍 Problem Resolved

- Previously, OOPS notes lacked a dedicated route per topic, making navigation and maintenance harder.
- Page titles remained static regardless of route, reducing clarity for users and SEO.

---

### ✅ What’s Changed

- Added explicit routes for each OOP topic:
- Registered routes in the main router for immediate access and improved organization.
- Implemented the new `JsPageTitleManager` component:
  - Listens to the active route and updates the browser tab title to match the topic.
  - Improves usability for tabbed browsing and searching, and optimizes SEO for individual topics.

---


### 🎯 Result

- Each OOP concept now has a clear, maintainable route for fast topic navigation.
- Titles update dynamically as users browse, helping users keep track of topics and improving discoverability.

---

### 🏷 Labels Requested

* `gssoc25`
* `frontend`
* `level3`

---


remove 