### PR TITLE
Improved Sidebar: Expand Category Based on Active Route

### DIFF
--- a/client/src/pages/Notes/JavaScriptFundamentals/components/JavaScriptNotesSideBar.jsx
+++ b/client/src/pages/Notes/JavaScriptFundamentals/components/JavaScriptNotesSideBar.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
 import { FiGithub, FiChevronRight, FiX } from 'react-icons/fi';
 import { motion, AnimatePresence } from 'framer-motion';
 import categories from "./JsSideBarData.json";
@@ -7,6 +7,7 @@ import useMobile from '../../../../hooks/useMobile';
 
 const JavaScriptNotesSidebar = ({ onNavigate }) => {
     const isMobile = useMobile(768);
+    const location = useLocation()
 
     const handleNavClick = () => {
         if (isMobile && onNavigate) {
@@ -14,7 +15,20 @@ const JavaScriptNotesSidebar = ({ onNavigate }) => {
         }
     };
 
-    const [expandedCategories, setExpandedCategories] = useState(new Set(Object.keys(categories).splice(0, 1)));
+    const [expandedCategories, setExpandedCategories] = useState(new Set());
+
+    // Set the initial expanded categories based on the current URL path
+    useEffect(() => {
+        // Look for the last path that is open, if that found in the sidebar -> if found expand that category else expand the first one.
+        let path = location.pathname.split('/').pop();
+        const category = Object.keys(categories).find(key => categories[key].some(item => item.toLowerCase().replace(/\s+/g, '-') === path));
+        if (category) {
+            setExpandedCategories(new Set([category]));
+        } else {
+            const category = Object.keys(categories)[0];
+            setExpandedCategories(new Set([category]));
+        }
+    }, []);
 
     const toggleCategory = (category) => {
         setExpandedCategories(prev => {

--- a/client/src/pages/Notes/JavaScriptFundamentals/components/JsSideBarData.json
+++ b/client/src/pages/Notes/JavaScriptFundamentals/components/JsSideBarData.json
@@ -1,7 +1,7 @@
 {
     "Introduction": ["Js Introduction", "JS execution", "Node.js Installation"],
     "JavaScript Variables": [
-        "What are Variables?",
+        "What are Variables",
         "Variable Naming Rules",
         "Primitives and Objects",
         "Operators and Expressions",


### PR DESCRIPTION
**Hi team 👋**

This PR updates the sidebar behavior to expand the topic category corresponding to the user's current route, creating a more intuitive and convenient navigation experience.

---

### 🔍 Problem Resolved

- Previously, the sidebar always expanded the first category of topics on every page refresh, regardless of which topic the user was viewing.
- This resulted in extra navigation steps, especially when deep-linking or revisiting a topic directly.

---

### ✅ What’s Changed

- The sidebar logic now dynamically checks the current route on render or page refresh.
- If the route matches a topic, the corresponding category is expanded automatically, keeping navigation contextually relevant.
- If no route match is found (e.g., on unknown or fallback routes), the sidebar defaults to expanding the first category for continuity and fallback UX.
- The change improves user flow and reduces friction for those reviewing or bookmarking specific topics.

---

### 🎯 Result

- Sidebar now reliably reflects the active topic’s category, minimizing clicks and orienting users faster.
- Maintains a sensible fallback by expanding the first category only when necessary.

---

### 🏷 Labels Requested

* `gssoc25`
* `frontend`
* `ux`
* `level2`

---
