### PR TITLE
"Back to Top" link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,3 +335,5 @@ Feel free to open issues or discussions if you have any feedback, feature sugges
 <img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&height=65&section=footer"/>
 
 **Ready to show off your coding achievements? Get started with Codify today! 🚀**
+
+[⬆️ Back to Top](#readme)


### PR DESCRIPTION
PR Description

This PR adds the "⬆️ Back to Top" link at the bottom of the README.md.

Changes Made

Updated the link target from # to #readme so it correctly scrolls back to the top of the README on GitHub.

Impact

Improves navigation for readers.

Ensures a smoother user experience when scrolling through the README.

Closes #382