### PR TITLE
 Add Git Topics Page Title Manager Component

### DIFF
--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -50,6 +50,7 @@ import GitHooks from './GitTopics/AdvanceGit/GitHooks'
 import GitInteractiveRebase from './GitTopics/AdvanceGit/GitInteractiveRebase'
 import GitSquashingCommits from './GitTopics/AdvanceGit/GitSquashingCommits'
 import GoodCommitMessages from './GitTopics/BestPractices/GoodCommitMessages'
+import BranchNamingConventions from './GitTopics/BestPractices/BranchNamingConventions'
 
 
 
@@ -265,6 +266,7 @@ const GitNotes = () => {
 
                 {/* Git best practices */}
                 <Route path='writing-good-commit-messages' element={<GoodCommitMessages />} />
+                <Route path='branch-naming-conventions' element={<BranchNamingConventions />} />
 
 
 

--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -49,6 +49,7 @@ import GitCherryPick from './GitTopics/AdvanceGit/GitCherryPick'
 import GitHooks from './GitTopics/AdvanceGit/GitHooks'
 import GitInteractiveRebase from './GitTopics/AdvanceGit/GitInteractiveRebase'
 import GitSquashingCommits from './GitTopics/AdvanceGit/GitSquashingCommits'
+import GoodCommitMessages from './GitTopics/BestPractices/GoodCommitMessages'
 
 
 
@@ -262,8 +263,8 @@ const GitNotes = () => {
                 <Route path='interactive-rebase' element={<GitInteractiveRebase />} />
                 <Route path='squashing-commits' element={<GitSquashingCommits />} />
 
-
-
+                {/* Git best practices */}
+                <Route path='writing-good-commit-messages' element={<GoodCommitMessages />} />
 
 
 

--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -51,6 +51,7 @@ import GitInteractiveRebase from './GitTopics/AdvanceGit/GitInteractiveRebase'
 import GitSquashingCommits from './GitTopics/AdvanceGit/GitSquashingCommits'
 import GoodCommitMessages from './GitTopics/BestPractices/GoodCommitMessages'
 import BranchNamingConventions from './GitTopics/BestPractices/BranchNamingConventions'
+import KeepingReposClean from './GitTopics/BestPractices/KeepingReposClean'
 
 
 
@@ -267,7 +268,7 @@ const GitNotes = () => {
                 {/* Git best practices */}
                 <Route path='writing-good-commit-messages' element={<GoodCommitMessages />} />
                 <Route path='branch-naming-conventions' element={<BranchNamingConventions />} />
-
+                <Route path='keeping-repositories-clean' element={<KeepingReposClean />} />
 
 
               </Routes>

--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -41,6 +41,7 @@ import GitCheckoutVsRestore from './GitTopics/GitUndoingChanges/GitCheckoutVsRes
 import GitRevert from './GitTopics/GitUndoingChanges/GitRevert'
 import GitResetExplained from './GitTopics/GitUndoingChanges/GitResetExplained'
 import GitStash from './GitTopics/GitStashAndTag/GitStash'
+import GitStashList from './GitTopics/GitStashAndTag/GitStashList'
 
 
 
@@ -243,7 +244,7 @@ const GitNotes = () => {
 
                 {/* Git stash and tag */}
                 <Route path='git-stash-save-&-git-stash-pop' element={<GitStash />} />
-
+                <Route path='git-stash-list' element={<GitStashList />} />
 
 
 

--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -44,6 +44,7 @@ import GitStash from './GitTopics/GitStashAndTag/GitStash'
 import GitStashList from './GitTopics/GitStashAndTag/GitStashList'
 import GitTagging from './GitTopics/GitStashAndTag/GitTagging'
 import TagTypesComparison from './GitTopics/GitStashAndTag/TagTypeComparison'
+import GitRebase from './GitTopics/AdvanceGit/GitRebase'
 
 
 
@@ -250,7 +251,8 @@ const GitNotes = () => {
                 <Route path='creating-tags-(git-tag)' element={<GitTagging />} />
                 <Route path='annotated-vs-lightweight-tags' element={<TagTypesComparison />} />
 
-
+                {/* Advance git */}
+                <Route path='rebasing-(git-rebase)' element={<GitRebase />} />
 
 
 

--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -52,6 +52,7 @@ import GitSquashingCommits from './GitTopics/AdvanceGit/GitSquashingCommits'
 import GoodCommitMessages from './GitTopics/BestPractices/GoodCommitMessages'
 import BranchNamingConventions from './GitTopics/BestPractices/BranchNamingConventions'
 import KeepingReposClean from './GitTopics/BestPractices/KeepingReposClean'
+import AvoidingLargeBinaries from './GitTopics/BestPractices/AvoidingLargeBinaries'
 
 
 
@@ -269,7 +270,7 @@ const GitNotes = () => {
                 <Route path='writing-good-commit-messages' element={<GoodCommitMessages />} />
                 <Route path='branch-naming-conventions' element={<BranchNamingConventions />} />
                 <Route path='keeping-repositories-clean' element={<KeepingReposClean />} />
-
+                <Route path='avoiding-large-binary-files' element={<AvoidingLargeBinaries />} />
 
               </Routes>
             </React.Suspense>

--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -42,6 +42,8 @@ import GitRevert from './GitTopics/GitUndoingChanges/GitRevert'
 import GitResetExplained from './GitTopics/GitUndoingChanges/GitResetExplained'
 import GitStash from './GitTopics/GitStashAndTag/GitStash'
 import GitStashList from './GitTopics/GitStashAndTag/GitStashList'
+import GitTagging from './GitTopics/GitStashAndTag/GitTagging'
+import TagTypesComparison from './GitTopics/GitStashAndTag/TagTypeComparison'
 
 
 
@@ -245,7 +247,8 @@ const GitNotes = () => {
                 {/* Git stash and tag */}
                 <Route path='git-stash-save-&-git-stash-pop' element={<GitStash />} />
                 <Route path='git-stash-list' element={<GitStashList />} />
-
+                <Route path='creating-tags-(git-tag)' element={<GitTagging />} />
+                <Route path='annotated-vs-lightweight-tags' element={<TagTypesComparison />} />
 
 
 

--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -40,6 +40,7 @@ import CodeReviewBasics from './GitTopics/CollabrativeWorkflow/CodeReviewBasics'
 import GitCheckoutVsRestore from './GitTopics/GitUndoingChanges/GitCheckoutVsRestore'
 import GitRevert from './GitTopics/GitUndoingChanges/GitRevert'
 import GitResetExplained from './GitTopics/GitUndoingChanges/GitResetExplained'
+import GitStash from './GitTopics/GitStashAndTag/GitStash'
 
 
 
@@ -238,6 +239,18 @@ const GitNotes = () => {
                 <Route path='git-checkout-vs-git-restore' element={<GitCheckoutVsRestore />} />
                 <Route path='git-revert' element={<GitRevert />} />
                 <Route path='git-reset-(soft,-mixed,-hard)' element={<GitResetExplained />} />
+
+
+                {/* Git stash and tag */}
+                <Route path='git-stash-save-&-git-stash-pop' element={<GitStash />} />
+
+
+
+
+
+
+
+
 
 
               </Routes>

--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -47,6 +47,7 @@ import TagTypesComparison from './GitTopics/GitStashAndTag/TagTypeComparison'
 import GitRebase from './GitTopics/AdvanceGit/GitRebase'
 import GitCherryPick from './GitTopics/AdvanceGit/GitCherryPick'
 import GitHooks from './GitTopics/AdvanceGit/GitHooks'
+import GitInteractiveRebase from './GitTopics/AdvanceGit/GitInteractiveRebase'
 
 
 
@@ -257,6 +258,7 @@ const GitNotes = () => {
                 <Route path='rebasing-(git-rebase)' element={<GitRebase />} />
                 <Route path='cherry-picking-(git-cherry-pick)' element={<GitCherryPick />} />
                 <Route path='git-hooks' element={<GitHooks />} />
+                <Route path='interactive-rebase' element={<GitInteractiveRebase />} />
 
 
 

--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -46,6 +46,7 @@ import GitTagging from './GitTopics/GitStashAndTag/GitTagging'
 import TagTypesComparison from './GitTopics/GitStashAndTag/TagTypeComparison'
 import GitRebase from './GitTopics/AdvanceGit/GitRebase'
 import GitCherryPick from './GitTopics/AdvanceGit/GitCherryPick'
+import GitHooks from './GitTopics/AdvanceGit/GitHooks'
 
 
 
@@ -255,6 +256,7 @@ const GitNotes = () => {
                 {/* Advance git */}
                 <Route path='rebasing-(git-rebase)' element={<GitRebase />} />
                 <Route path='cherry-picking-(git-cherry-pick)' element={<GitCherryPick />} />
+                <Route path='git-hooks' element={<GitHooks />} />
 
 
 

--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -53,6 +53,7 @@ import GoodCommitMessages from './GitTopics/BestPractices/GoodCommitMessages'
 import BranchNamingConventions from './GitTopics/BestPractices/BranchNamingConventions'
 import KeepingReposClean from './GitTopics/BestPractices/KeepingReposClean'
 import AvoidingLargeBinaries from './GitTopics/BestPractices/AvoidingLargeBinaries'
+import GitPageTitleManager from './GitPageTitleManager'
 
 
 
@@ -199,7 +200,7 @@ const GitNotes = () => {
           <Breadcrumb isSidebarOpen={isSidebarOpen} toggleSidebar={toggleSidebar} className={"p-4"} />
 
           {/* Page Title Manager */}
-          {/* <GitPageTitleManager /> */}
+          <GitPageTitleManager />
 
           {/* ROUTES OF THE SUB NOTES */}
           <div className="p-4 md:p-8">

--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -45,6 +45,7 @@ import GitStashList from './GitTopics/GitStashAndTag/GitStashList'
 import GitTagging from './GitTopics/GitStashAndTag/GitTagging'
 import TagTypesComparison from './GitTopics/GitStashAndTag/TagTypeComparison'
 import GitRebase from './GitTopics/AdvanceGit/GitRebase'
+import GitCherryPick from './GitTopics/AdvanceGit/GitCherryPick'
 
 
 
@@ -253,6 +254,7 @@ const GitNotes = () => {
 
                 {/* Advance git */}
                 <Route path='rebasing-(git-rebase)' element={<GitRebase />} />
+                <Route path='cherry-picking-(git-cherry-pick)' element={<GitCherryPick />} />
 
 
 

--- a/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitNotes.jsx
@@ -48,6 +48,7 @@ import GitRebase from './GitTopics/AdvanceGit/GitRebase'
 import GitCherryPick from './GitTopics/AdvanceGit/GitCherryPick'
 import GitHooks from './GitTopics/AdvanceGit/GitHooks'
 import GitInteractiveRebase from './GitTopics/AdvanceGit/GitInteractiveRebase'
+import GitSquashingCommits from './GitTopics/AdvanceGit/GitSquashingCommits'
 
 
 
@@ -259,6 +260,7 @@ const GitNotes = () => {
                 <Route path='cherry-picking-(git-cherry-pick)' element={<GitCherryPick />} />
                 <Route path='git-hooks' element={<GitHooks />} />
                 <Route path='interactive-rebase' element={<GitInteractiveRebase />} />
+                <Route path='squashing-commits' element={<GitSquashingCommits />} />
 
 
 

--- a/client/src/pages/Notes/GitVersionControl/GitPageTitleManager.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitPageTitleManager.jsx
@@ -1,0 +1,84 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+
+const gitRoutesAndTitles = {
+    // Introduction
+    "/notes/git": "Master Git & Version Control | Codify",
+    "/notes/git/what-is-version-control": "What is Version Control? | Codify",
+    "/notes/git/benefits-of-version-control": "Benefits of Version Control | Codify",
+    "/notes/git/centralized-vs-distributed-version-control": "Centralized vs Distributed Version Control | Codify",
+
+    // Getting Started with Git
+    "/notes/git/installing-git": "Installing Git | Codify",
+    "/notes/git/configuring-git-(username,-email,-editor)": "Configuring Git (Username, Email, Editor) | Codify",
+    "/notes/git/understanding-git-architecture": "Understanding Git Architecture | Codify",
+    "/notes/git/initializing-a-repository-(git-init)": "Initializing a Repository (git init) | Codify",
+
+    // Basic Git Commands
+    "/notes/git/git-status": "Git Status | Codify",
+    "/notes/git/git-add": "Git Add | Codify",
+    "/notes/git/git-commit": "Git Commit | Codify",
+    "/notes/git/git-log": "Git Log | Codify",
+    "/notes/git/git-diff": "Git Diff | Codify",
+    "/notes/git/git-reset": "Git Reset | Codify",
+
+    // Branching and Merging
+    "/notes/git/creating-branches-(git-branch,-git-checkout--b)": "Creating Branches (git branch, git checkout -b) | Codify",
+    "/notes/git/merging-branches-(git-merge)": "Merging Branches (git merge) | Codify",
+    "/notes/git/fast-forward-vs-three-way-merge": "Fast-forward vs Three-way merge | Codify",
+    "/notes/git/resolving-merge-conflicts": "Resolving Merge Conflicts | Codify",
+    "/notes/git/deleting-branches-(git-branch--d)": "Deleting Branches (git branch -d) | Codify",
+
+    // Remote Repositories
+    "/notes/git/what-is-a-remote-repository": "What is a Remote Repository? | Codify",
+    "/notes/git/git-remote-add": "Git Remote Add | Codify",
+    "/notes/git/git-push-and-git-pull": "Git Push and Git Pull | Codify",
+    "/notes/git/git-fetch": "Git Fetch | Codify",
+    "/notes/git/tracking-branches": "Tracking Branches | Codify",
+
+    // Collaboration Workflows
+    "/notes/git/cloning-a-repository-(git-clone)": "Cloning a Repository (git clone) | Codify",
+    "/notes/git/forking-workflow": "Forking Workflow | Codify",
+    "/notes/git/pull-requests": "Pull Requests | Codify",
+    "/notes/git/code-review-basics": "Code Review Basics | Codify",
+
+    // Undoing Changes
+    "/notes/git/git-checkout-vs-git-restore": "Git Checkout vs Git Restore | Codify",
+    "/notes/git/git-revert": "Git Revert | Codify",
+    "/notes/git/git-reset-(soft,-mixed,-hard)": "Git Reset (soft, mixed, hard) | Codify",
+
+    // Stashing and Tagging
+    "/notes/git/git-stash-save-&-git-stash-pop": "Git Stash Save & Git Stash Pop | Codify",
+    "/notes/git/git-stash-list": "Git Stash List | Codify",
+    "/notes/git/creating-tags-(git-tag)": "Creating Tags (git tag) | Codify",
+    "/notes/git/annotated-vs-lightweight-tags": "Annotated vs Lightweight Tags | Codify",
+
+    // Advanced Git
+    "/notes/git/rebasing-(git-rebase)": "Rebasing (git rebase) | Codify",
+    "/notes/git/cherry-picking-(git-cherry-pick)": "Cherry-picking (git cherry-pick) | Codify",
+    "/notes/git/git-hooks": "Git Hooks | Codify",
+    "/notes/git/interactive-rebase": "Interactive Rebase | Codify",
+    "/notes/git/squashing-commits": "Squashing Commits | Codify",
+
+    // Git Best Practices
+    "/notes/git/writing-good-commit-messages": "Writing Good Commit Messages | Codify",
+    "/notes/git/branch-naming-conventions": "Branch Naming Conventions | Codify",
+    "/notes/git/keeping-repositories-clean": "Keeping Repositories Clean | Codify",
+    "/notes/git/avoiding-large-binary-files": "Avoiding Large Binary Files | Codify"
+};
+
+
+
+const GitPageTitleManager = () => {
+    const location = useLocation();
+
+    useEffect(() => {
+        console.log(location.pathname)
+        const pageTitle = gitRoutesAndTitles[location.pathname] || "Codify";
+        document.title = pageTitle;
+    }, [location]);
+
+    return null;
+}
+
+export default GitPageTitleManager

--- a/client/src/pages/Notes/GitVersionControl/GitTopics.json
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics.json
@@ -26,7 +26,7 @@
         "Deleting Branches (git branch -d)"
     ],
     "Remote Repositories": [
-        "What is a Remote Repository?",
+        "What is a Remote Repository",
         "git remote add",
         "git push and git pull",
         "git fetch",

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/AdvanceGit/GitCherryPick.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/AdvanceGit/GitCherryPick.jsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const GitCherryPick = () => {
+    const examples = [
+        {
+            title: 'Basic Cherry-Pick',
+            code: `# Step 1: Find the commit hash you want from another branch
+git log feature-branch --oneline
+# 7a4e9b3 Add new login button <--- This is the commit we want
+# 3c8e1a2 Refactor API service
+
+# Step 2: Switch to the branch where you want to apply the commit
+git switch main
+
+# Step 3: Cherry-pick the commit
+git cherry-pick 7a4e9b3`,
+            explanation: 'This command takes the changes from the specified commit and applies them to your current branch, creating a new commit with the same changes.'
+        },
+        {
+            title: 'Cherry-Picking a Range of Commits',
+            code: `# Suppose we want commits B and C from another branch
+# A -- B -- C -- D (feature-branch)
+
+# Find the commit hashes
+git log feature-branch --oneline
+# ...
+# 3c8e1a2 (C) Refactor API service
+# 7a4e9b3 (B) Add new login button
+# ...
+
+# Apply commits B and C onto the current branch
+# The A..C syntax means "commits after A, up to and including C"
+git cherry-pick 7a4e9b3^..3c8e1a2`,
+            explanation: 'You can cherry-pick a range of commits. The `^..` notation is useful for including the starting commit in the range.'
+        }
+    ];
+
+    const workflows = [
+        {
+            title: 'Workflow: Applying a Hotfix',
+            code: `# A critical bug is fixed on the main branch
+git log main --oneline
+# 9fceb02 Fix critical bug in API <--- The hotfix commit
+# ...
+
+# The same fix needs to be applied to an older release branch
+git switch release-v1.0
+
+# Cherry-pick the hotfix commit onto the release branch
+git cherry-pick 9fceb02`,
+            explanation: 'Cherry-picking is ideal for backporting critical fixes to maintenance branches without bringing in other, newer features from the main branch.'
+        },
+        {
+            title: 'Handling Conflicts',
+            code: `# Start the cherry-pick
+git cherry-pick 7a4e9b3
+# Auto-merging index.js
+# CONFLICT (content): Merge conflict in index.js
+# error: could not apply 7a4e9b3... Add new login button
+
+# Step 1: Open the file(s) with conflicts and resolve them manually
+# Step 2: Stage the resolved file(s)
+git add index.js
+
+# Step 3: Continue the cherry-pick process
+git cherry-pick --continue
+
+# Alternatively, to cancel the whole operation:
+git cherry-pick --abort`,
+            explanation: 'If the changes in the picked commit conflict with your current branch, Git will pause and let you resolve the conflicts manually.'
+        }
+    ];
+
+    const bestPractices = [
+        'Use cherry-pick for very specific situations like hotfixes or backporting a small change.',
+        'Prefer `git merge` or `git rebase` for integrating entire feature branches.',
+        'Always review the changes you are about to cherry-pick to understand their context.',
+        'Communicate with your team when cherry-picking to avoid confusion about duplicated commits in the history.',
+        'Test thoroughly after a cherry-pick, as the code is being applied in a new context.'
+    ];
+
+    const commonMistakes = [
+        'Using cherry-pick when a standard `git merge` would be more appropriate.',
+        'Thinking it moves a commit. It copies the changes into a new, distinct commit.',
+        'Cherry-picking a commit that relies on changes from other commits that are not being picked.',
+        'Losing track of which commits have been cherry-picked, leading to a messy history.',
+        'Mishandling conflicts, leading to a broken state.'
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                <span className="text-primary-600 dark:text-primary-400">Git</span> Cherry-Pick: Applying Specific Commits
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    `git cherry-pick` is a powerful command that allows you to choose a commit from one branch and apply it onto another. This is in contrast to `git merge`, which applies all the commits from another branch. Cherry-picking is a surgical tool, enabling you to grab individual changes that you need.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold">Key Concept: </strong>
+                        Cherry-picking doesn't move a commit; it takes the patch (the set of changes) from the target commit and reapplies it on your current branch, creating a brand new commit with a different hash.
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Basic Usage</h2>
+                    <div className="space-y-6">
+                        {examples.map((example, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{example.title}</h3>
+                                <CodeBlock code={example.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{example.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Workflows & Conflict Resolution</h2>
+                    <div className="space-y-6">
+                        {workflows.map((workflow, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{workflow.title}</h3>
+                                <CodeBlock code={workflow.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{workflow.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <div className="grid md:grid-cols-2 gap-6 mb-8">
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Best Practices</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {bestPractices.map((practice, index) => (
+                                <li key={`best-${index}`} className="text-sm">{practice}</li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Common Mistakes</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {commonMistakes.map((mistake, index) => (
+                                <li key={`mistake-${index}`} className="text-sm">{mistake}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+                 <div className="mt-8 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <h3 className="text-lg font-semibold text-primary-600 dark:text-primary-400 mb-2">When to Use Cherry-Pick vs. Merge</h3>
+                     <p className="text-gray-700 dark:text-gray-300 mb-4">
+                        Choosing the right tool is crucial for maintaining a clean project history.
+                    </p>
+                    <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300 mb-4">
+                        <li><strong>`git cherry-pick`</strong>: For applying a *single commit* from another branch. Use for hotfixes, backporting fixes, or reapplying a commit made to the wrong branch.</li>
+                        <li><strong>`git merge`</strong>: For integrating an *entire branch's history* into another. This is the standard way to combine feature branches with your main line of development.</li>
+                    </ul>
+                </div>
+
+            </div>
+        </div>
+    );
+};
+
+export default GitCherryPick;

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/AdvanceGit/GitHooks.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/AdvanceGit/GitHooks.jsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const GitHooks = () => {
+    const commonHooks = [
+        {
+            name: 'pre-commit',
+            type: 'Client-Side',
+            description: 'This hook is run first, before you even type in a commit message. It’s used to inspect the snapshot that’s about to be committed.',
+            use_cases: 'Run linters (ESLint, Prettier), run fast unit tests, check for code style violations. If the script exits non-zero, the commit is aborted.'
+        },
+        {
+            name: 'prepare-commit-msg',
+            type: 'Client-Side',
+            description: 'This hook runs before the commit message editor is fired up but after the default message is created. It lets you edit the default message programmatically.',
+            use_cases: 'Automatically insert a ticket/issue number from the branch name into the commit message.'
+        },
+        {
+            name: 'commit-msg',
+            type: 'Client-Side',
+            description: 'This hook takes one argument: the path to a temporary file that contains the commit message. It runs after you close the commit message editor.',
+            use_cases: 'Validate that the commit message follows a required pattern (e.g., Conventional Commits). Aborts the commit if the message is invalid.'
+        },
+        {
+            name: 'post-commit',
+            type: 'Client-Side',
+            description: 'This hook runs after the commit is made. It doesn’t take any parameters and its exit status doesn’t affect the commit in any way.',
+            use_cases: 'Sending notifications, triggering a local build, or updating documentation files.'
+        },
+        {
+            name: 'pre-receive',
+            type: 'Server-Side',
+            description: 'This is the first script to run when handling a push from a client. It runs on the remote repository before any references are updated.',
+            use_cases: 'Enforce project policies like preventing force pushes, ensuring commit messages meet standards, or blocking pushes that don\'t pass integration tests.'
+        }
+    ];
+
+    const practicalExample = {
+        title: 'Example: A Simple `pre-commit` Hook',
+        explanation: 'This shell script will run your project\'s tests. If any test fails, the script will exit with a non-zero status, which tells Git to abort the commit.',
+        code: `#!/bin/sh
+
+# Navigate to the project root
+cd "$(git rev-parse --show-toplevel)"
+
+echo "Running tests before commit..."
+
+# Run the test command
+npm test
+
+# Check the exit code of the last command
+if [ $? -ne 0 ]; then
+    echo "Tests failed. Commit aborted."
+    exit 1 # Exit with a non-zero status to abort the commit
+fi
+
+echo "All tests passed. Proceeding with commit."
+exit 0 # Exit with zero to allow the commit
+`
+    };
+
+    const bestPractices = [
+        'Keep hooks fast. Slow hooks can frustrate developers and discourage their use.',
+        'Hooks are not versioned with your project. Use tools like Husky to share hooks across your team.',
+        'Provide clear, actionable error messages when a hook fails.',
+        'Remember that users can bypass client-side hooks with `git commit --no-verify`.',
+        'Write hooks in a language that is common and accessible to your team (Shell, Node.js, Python).'
+    ];
+
+    const commonMistakes = [
+        'Forgetting to make the hook script executable (`chmod +x .git/hooks/pre-commit`).',
+        'Assuming a specific environment or dependency is installed on every developer\'s machine.',
+        'Writing overly complex logic inside a hook instead of calling a dedicated script in your project.',
+        'Not accounting for different operating systems (e.g., Windows vs. macOS/Linux).',
+        'Relying solely on client-side hooks for policy enforcement; critical checks should be server-side.'
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                <span className="text-primary-600 dark:text-primary-400">Git Hooks:</span> Automating Your Workflow
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    Git hooks are custom scripts that Git executes automatically before or after key events such as `commit`, `push`, and `receive`. They are a powerful feature for automating tasks, enforcing policies, and customizing your workflow. Hooks are stored in the `.git/hooks` directory of every repository but are not versioned with the project itself.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold">Key Concept: </strong>
+                        Git hooks act as event listeners for your repository. By writing a script and giving it the correct filename, you can "hook into" a specific moment in the Git lifecycle to run your own custom logic.
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Commonly Used Hooks</h2>
+                    <div className="space-y-6">
+                        {commonHooks.map((hook, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <div className="flex justify-between items-center mb-2">
+                                    <h3 className="text-lg font-semibold text-gray-800 dark:text-white">{hook.name}</h3>
+                                    <span className={`text-xs font-medium px-2 py-1 rounded-full ${hook.type === 'Client-Side' ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300' : 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300'}`}>
+                                        {hook.type}
+                                    </span>
+                                </div>
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mb-3">{hook.description}</p>
+                                <p className="text-sm text-gray-600 dark:text-gray-400"><strong className="font-semibold text-gray-700 dark:text-gray-300">Use Cases:</strong> {hook.use_cases}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">How to Implement a Hook</h2>
+                     <div className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                        <p className="text-gray-700 dark:text-gray-300 mb-4">
+                            To enable a hook, navigate to your repository's `.git/hooks` directory. You'll see a number of sample files (e.g., `pre-commit.sample`). To activate a hook, simply rename the file by removing the `.sample` extension. Then, make the file executable and fill it with your script.
+                        </p>
+                        <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{practicalExample.title}</h3>
+                        <CodeBlock code={practicalExample.code} language="bash" />
+                        <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{practicalExample.explanation}</p>
+                    </div>
+                </section>
+
+                <div className="grid md:grid-cols-2 gap-6 mb-8">
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Best Practices</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {bestPractices.map((practice, index) => (
+                                <li key={`best-${index}`} className="text-sm">{practice}</li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Common Mistakes</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {commonMistakes.map((mistake, index) => (
+                                <li key={`mistake-${index}`} className="text-sm">{mistake}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default GitHooks;

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/AdvanceGit/GitInteractiveRebase.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/AdvanceGit/GitInteractiveRebase.jsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const GitInteractiveRebase = () => {
+    const commonOps = [
+        {
+            title: 'Combining Commits (`squash` & `fixup`)',
+            code: `#
+pick 223c3e7 Add basic HTML structure
+s 8f8f2d1 Add header and nav styles  # 's' is short for 'squash'
+f 9a1b4c5 Fix typo in header       # 'f' is short for 'fixup'
+
+# After saving, Git will open another editor to combine messages
+# from the 'pick' and 'squash' commits. The 'fixup' message
+# will be discarded automatically.`,
+            explanation: '`squash` combines commits and lets you edit the commit messages together. `fixup` is similar but discards the message of the fixed-up commit entirely.'
+        },
+        {
+            title: 'Rewording a Commit Message (`reword`)',
+            code: `# Simply change 'pick' to 'reword' (or 'r')
+r 223c3e7 Add basic HTML structure
+
+# After saving, Git will open an editor allowing you to
+# write a new commit message for this specific commit.`,
+            explanation: '`reword` is perfect for quickly fixing typos or improving the clarity of a commit message without changing the code.'
+        },
+        {
+            title: 'Reordering and Dropping Commits',
+            code: `# To reorder, just change the order of the lines:
+pick 9a1b4c5 A feature
+pick 223c3e7 A dependency for that feature
+# becomes ->
+pick 223c3e7 A dependency for that feature
+pick 9a1b4c5 A feature
+
+# To drop a commit, delete the line or use 'drop' ('d')
+d 8f8f2d1 Remove this commit entirely`,
+            explanation: 'You can change the order in which commits are applied by reordering them in the list. To completely remove a commit, simply delete its line or use the `drop` command.'
+        }
+    ];
+
+    const bestPractices = [
+        '**Rule #1: NEVER** rebase commits that you have pushed and shared with others.',
+        'Rebase in small, logical chunks. It\'s easier to resolve issues than in one giant rebase.',
+        'Clean up your local feature branch history *before* creating a pull request.',
+        'Use `squash` and `fixup` to turn messy "WIP" commits into a single, coherent feature commit.',
+        'If you get stuck, remember you can always escape with `git rebase --abort`.'
+    ];
+
+    const commonMistakes = [
+        'Rebasing the `main` branch or any other shared, long-lived branch.',
+        'Rewriting history that another developer has already based their work on.',
+        'Trying to rebase a massive feature branch with hundreds of commits at once.',
+        'Not knowing how to resolve rebase conflicts when they occur.',
+        'Using `git push --force` instead of the safer `git push --force-with-lease`.'
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                <span className="text-primary-600 dark:text-primary-400">Git</span> Interactive Rebase
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    Interactive rebase is one of Git's most powerful features. It allows you to modify commits, rewrite messages, and change history in a variety of ways. It's the ultimate tool for cleaning up a messy local commit history on your feature branch before sharing it with your team.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-yellow-400 dark:border-yellow-600 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold text-yellow-600 dark:text-yellow-500">⚠️ Important: </strong>
+                        With great power comes great responsibility. Interactive rebase rewrites commit history. You should **only** use it on commits that have not yet been pushed to a shared repository.
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Starting an Interactive Rebase Session</h2>
+                    <div className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                        <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">The Command</h3>
+                         <p className="text-gray-700 dark:text-gray-300 text-sm mb-2">You can start a session relative to your current position (`HEAD`) or against another branch.</p>
+                        <CodeBlock code={`# Rebase the last 3 commits from your current position
+git rebase -i HEAD~3
+
+# Rebase all commits on your current branch that are not on 'main'
+git rebase -i main`} language="bash" />
+                        <p className="text-gray-700 dark:text-gray-300 text-sm mt-4">After running this, Git will open your default text editor with a list of the commits you've selected, along with instructions.</p>
+                         <CodeBlock code={`# This is what you'll see in your editor:
+pick 223c3e7 Add basic HTML structure
+pick 8f8f2d1 Add header styles
+pick 9a1b4c5 Fix typo in header
+
+# Rebase 5d8f3b4..9a1b4c5 onto 5d8f3b4 (3 commands)
+#
+# Commands:
+# p, pick <commit> = use commit
+# r, reword <commit> = use commit, but edit the commit message
+# e, edit <commit> = use commit, but stop for amending
+# s, squash <commit> = use commit, but meld into previous commit
+# f, fixup <commit> = like "squash", but discard this commit's log message
+# ... and more`} language="bash" />
+
+                    </div>
+                </section>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Common Operations</h2>
+                    <div className="space-y-6">
+                        {commonOps.map((op, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{op.title}</h3>
+                                <CodeBlock code={op.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{op.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <div className="grid md:grid-cols-2 gap-6 mb-8">
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Best Practices</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {bestPractices.map((practice, index) => (
+                                <li key={`best-${index}`} className="text-sm" dangerouslySetInnerHTML={{ __html: practice }} />
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Common Mistakes</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {commonMistakes.map((mistake, index) => (
+                                <li key={`mistake-${index}`} className="text-sm">{mistake}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+
+                <div className="mt-8 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <h3 className="text-lg font-semibold text-primary-600 dark:text-primary-400 mb-2">The Golden Rule of Rebasing & Pushing</h3>
+                    <p className="text-gray-700 dark:text-gray-300 mb-4">
+                        After rewriting history on your local feature branch, you will have to "force push" to update the remote branch. Use `--force-with-lease` as a safety check to avoid overwriting work if someone else has pushed to the branch.
+                    </p>
+                    <CodeBlock
+                        code={`# On your feature branch...
+# 1. Clean up your local history
+git rebase -i main
+
+# 2. Push your cleaned-up branch
+# This will fail if someone else has pushed to your branch since you last pulled.
+git push --force-with-lease origin my-feature-branch`}
+                        language="bash"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default GitInteractiveRebase;

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/AdvanceGit/GitRebase.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/AdvanceGit/GitRebase.jsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const GitRebase = () => {
+    const comparison = [
+        {
+            title: 'Merge Workflow',
+            code: `# Starting point:
+# A---B---C (main)
+#      \\
+#       D---E---F (feature)
+
+# Merge 'feature' into 'main'
+git switch main
+git merge feature
+
+# Result: A new merge commit is created
+# A---B---C---G (main)
+#      \\     /
+#       D---E---F (feature)`,
+            explanation: 'Merging ties two histories together by creating a new merge commit. It preserves the exact history of both branches but can result in a complex, non-linear graph.'
+        },
+        {
+            title: 'Rebase Workflow',
+            code: `# Starting point:
+# A---B---C (main)
+#      \\
+#       D---E---F (feature)
+
+# Rebase 'feature' onto 'main'
+git switch feature
+git rebase main
+
+# Result: 'feature' commits are re-written on top of 'main'
+# A---B---C---D'---E'---F' (feature)
+#           (main)`,
+            explanation: 'Rebasing rewrites history by re-applying commits from one branch on top of another. This creates a clean, linear history but alters the commit hashes (D\', E\', F\').'
+        }
+    ];
+
+    const practicalExamples = [
+        {
+            title: 'Standard Rebase Process',
+            code: `# 1. Make sure your main branch is up-to-date
+git switch main
+git pull origin main
+
+# 2. Switch to your feature branch
+git switch feature
+
+# 3. Rebase it on top of the main branch
+git rebase main
+
+# Now your feature branch has all of its work, plus main's latest changes.`,
+            explanation: 'This workflow "updates" your feature branch with the latest progress from the main branch, making the final merge much cleaner.'
+        },
+        {
+            title: 'Handling Conflicts during Rebase',
+            code: `# If a conflict occurs, Git will pause the rebase:
+# CONFLICT (content): Merge conflict in file.js
+
+# 1. Open the file and resolve the conflict manually
+# 2. Stage the resolved file
+git add file.js
+
+# 3. Continue the rebase process
+git rebase --continue
+
+# (Or, to cancel the entire rebase)
+git rebase --abort`,
+            explanation: 'Unlike a merge where you resolve all conflicts at once, a rebase presents conflicts one commit at a time, allowing you to address them sequentially as they are re-applied.'
+        }
+    ];
+
+    const bestPractices = [
+        'Rebase your feature branch onto the target branch (e.g., `main`) to pull in upstream changes before creating a pull request.',
+        'Use **interactive rebase** (`git rebase -i`) to clean up your local commit history (squash, reword, etc.) before sharing your work.',
+        'Use `git pull --rebase` to avoid creating messy merge commits when updating your local tracking branches.'
+    ];
+
+    const goldenRule = [
+        'This rule is absolute. Rebasing rewrites history by creating new commits.',
+        'If you rebase a branch that others are working on, their history will diverge from yours.',
+        'This forces everyone to manually fix their local history, creating confusion and potential for lost work.',
+        '**It is safe to rebase your own local branches that you have not yet shared.**'
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                <span className="text-primary-600 dark:text-primary-400">Git</span> Rebasing: Creating a Linear History
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    `git rebase` is one of Git's most powerful—and misunderstood—commands. Its primary function is to re-apply a sequence of commits on top of a different base commit. This is most often used to create a "cleaner" or more linear project history by avoiding unnecessary merge commits.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover-border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold">Key Concept: </strong>
+                        The core difference is how histories are combined. **Merge** preserves history exactly as it happened by creating a new merge commit. **Rebase** rewrites history by moving your commits, resulting in a straight line of commits.
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Rebase vs. Merge Illustrated</h2>
+                    <div className="space-y-6">
+                        {comparison.map((item, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{item.title}</h3>
+                                <CodeBlock code={item.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{item.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">The Rebase Process</h2>
+                    <div className="space-y-6">
+                        {practicalExamples.map((example, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{example.title}</h3>
+                                <CodeBlock code={example.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{example.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <div className="grid md:grid-cols-2 gap-6 mb-8">
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Best Practices</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {bestPractices.map((practice, index) => (
+                                <li key={`best-${index}`} className="text-sm">{practice}</li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-red-300 dark:border-red-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-red-600 dark:text-red-400 mb-4">The Golden Rule of Rebasing</h3>
+                        <p className="text-sm font-bold text-gray-800 dark:text-gray-200 mb-3">Do not rebase commits that exist outside your repository and that other people may have based their work on.</p>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {goldenRule.map((rule, index) => (
+                                <li key={`rule-${index}`} className="text-sm">{rule}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+
+                <div className="mt-8 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <h3 className="text-lg font-semibold text-primary-600 dark:text-primary-400 mb-2">Power Tool: Interactive Rebase</h3>
+                    <p className="text-gray-700 dark:text-gray-300 mb-4">
+                        Interactive rebase (`-i`) allows you to alter commits as they are moved. You can edit, reword, combine (squash), or drop commits entirely, giving you complete control over your branch's history before sharing it.
+                    </p>
+                    <CodeBlock
+                        code={`# Rebase the last 3 commits interactively
+git rebase -i HEAD~3
+
+# This opens an editor with a list of commits:
+# pick 1fc6c95 Add login button
+# pick 6b2481b Fix button alignment
+# pick f7fde4a Change button color
+#
+# Replace 'pick' with 'squash' or 'fixup' to combine commits,
+# 'reword' to change the message, 'drop' to delete, etc.`}
+                        language="bash"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default GitRebase;

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/AdvanceGit/GitSquashingCommits.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/AdvanceGit/GitSquashingCommits.jsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const GitSquashingCommits = () => {
+    const processSteps = [
+        {
+            title: '1. Identify Commits to Squash',
+            code: `# Let's say our history looks messy like this:
+git log --oneline
+# 7c3d4a1 Add forgotten semicolon
+# 3a2c1d0 WIP on user form
+# 5d8f3b4 Start implementing user form
+
+# We want to combine these 3 commits into one.
+# Start an interactive rebase for the last 3 commits:
+git rebase -i HEAD~3`,
+            explanation: 'First, identify the series of commits you want to combine. Then, start an interactive rebase with `git rebase -i`, specifying the range of commits to work with.'
+        },
+        {
+            title: '2. Mark Commits for Squashing',
+            code: `# Your text editor will open with the following:
+pick 5d8f3b4 Start implementing user form
+pick 3a2c1d0 WIP on user form
+pick 7c3d4a1 Add forgotten semicolon
+
+# To squash, change "pick" to "squash" (or "s") for the commits
+# you want to merge into the one above them.
+pick 5d8f3b4 Start implementing user form
+s 3a2c1d0 WIP on user form
+s 7c3d4a1 Add forgotten semicolon
+
+# Save and close the editor.`,
+            explanation: 'In the interactive editor, keep `pick` for the first commit and change `pick` to `squash` or `s` for all the subsequent commits you want to combine.'
+        },
+        {
+            title: '3. Craft the New Commit Message',
+            code: `# Git will now open another editor to create the new commit message.
+# This is a combination of all the messages from the squashed commits.
+#
+#   Start implementing user form
+#   WIP on user form
+#   Add forgotten semicolon
+
+# Delete the old messages and write a new, clean, and descriptive one.
+# For example:
+Implement user form with validation
+
+# - Add form component structure
+# - Include email and password fields
+# - Add client-side validation for both fields
+
+# Save and close the editor.`,
+            explanation: 'After choosing which commits to squash, Git prompts you to write a new commit message. It\'s best practice to discard the old messages and write a single, comprehensive message that describes the entire change.'
+        },
+        {
+            title: '4. The Final, Clean History',
+            code: `# Check the log again
+git log --oneline
+
+# --- New Output ---
+# f4a3b2c Implement user form with validation`,
+            explanation: 'The original three commits have now been replaced by a single, well-worded commit, resulting in a much cleaner project history.'
+        },
+    ];
+
+    const bestPractices = [
+        'Squash only on your local feature branches before they are merged.',
+        'Combine small, related commits (like "fix typo", "WIP", "add test") into a single logical feature.',
+        'Write a clear and comprehensive new commit message that summarizes the entire change.',
+        'Ensure your code is in a stable, working state before starting a squash.',
+        'Use squashing to make your pull requests easier to review and understand.'
+    ];
+
+    const commonMistakes = [
+        '**The Golden Rule:** Never squash commits that have already been pushed to a shared branch (like `main` or `develop`). This rewrites history and can cause major issues for your teammates.',
+        'Squashing unrelated changes into a single, confusing commit.',
+        'Force-pushing (`git push --force`) to a shared branch after squashing.',
+        'Writing a lazy commit message for the new, combined commit.',
+        'Accidentally resolving merge conflicts incorrectly during the rebase process.'
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                <span className="text-primary-600 dark:text-primary-400">Git</span> Squashing Commits
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    Squashing in Git is the process of combining a sequence of commits into a single, cohesive commit. It's not a standalone command, but rather a powerful feature of interactive rebase (`git rebase -i`). The primary goal is to clean up your project's history, turning a series of messy "work-in-progress" commits into one logical change.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold">Key Concept: </strong>
+                        Squashing transforms a messy local history into a clean, understandable story. It's a cleanup step you perform on your feature branch *before* sharing your code, ensuring your contribution is presented as a single, logical unit.
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">The Squashing Process</h2>
+                    <div className="space-y-6">
+                        {processSteps.map((step, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{step.title}</h3>
+                                <CodeBlock code={step.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{step.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <div className="grid md:grid-cols-2 gap-6 mb-8">
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Best Practices</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {bestPractices.map((practice, index) => (
+                                <li key={`best-${index}`} className="text-sm">{practice}</li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-red-300 dark:border-red-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Common Mistakes & The Golden Rule</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {commonMistakes.map((mistake, index) => (
+                                <li key={`mistake-${index}`} className="text-sm">{mistake}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default GitSquashingCommits;

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/BestPractices/AvoidingLargeBinaries.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/BestPractices/AvoidingLargeBinaries.jsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const AvoidingLargeBinaries = () => {
+    const problemsAndSolutions = [
+        {
+            title: 'The Problem with Large Files',
+            code: `# A typical repo might contain source code and assets
+project/
+├── src/
+│   └── main.js       # Text, diffs well
+├── assets/
+│   └── design.psd    # Binary, 250MB, does NOT diff well
+└── README.md         # Text, diffs well`,
+            explanation: 'Git is optimized for text files, where it can efficiently store the differences (deltas) between versions. For binary files (images, videos, executables), any small change often forces Git to store a complete new copy of the file, causing the repository size to grow extremely fast.'
+        },
+        {
+            title: 'The Consequences of a Bloated Repository',
+            list: [
+                '🐌 Slow Operations: `git clone`, `fetch`, and `pull` become painfully slow for the entire team.',
+                '💾 Excessive Disk Usage: The `.git` directory can become many times larger than the actual project files.',
+                '🚫 Hosting Limits: Services like GitHub have repository size limits (e.g., a 100MB file limit) that you can easily exceed.',
+                '😩 Difficult to Fix: Removing large files from a repository\'s history is a complex and destructive process.'
+            ],
+            explanation: 'A large repository impacts the productivity of every single person who works with it.'
+        },
+        {
+            title: 'The Solution: Git Large File Storage (LFS)',
+            code: `# Step 1: Tell LFS which file patterns to track
+git lfs track "*.psd"
+
+# Step 2: Add the tracking configuration file to git
+git add .gitattributes
+
+# When you add a PSD, Git stores a tiny POINTER, not the 250MB file
+git add assets/design.psd
+
+# The actual file is uploaded to a separate LFS server on push
+git push`,
+            explanation: 'Git LFS solves this by storing large files on a separate server. It replaces them in your repository with small text pointers. When you check out a branch, LFS downloads the files you need.'
+        }
+    ];
+
+    const bestPractices = [
+        'Set up Git LFS (`git lfs track`) *before* you add any large files to the repository.',
+        'Always make sure the `.gitattributes` file is committed so the rules are shared with your team.',
+        'Use `.gitignore` for files that should never be tracked at all (e.g., build outputs, dependency folders).',
+        'Regularly audit what is being tracked by LFS using the `git lfs ls-files` command.',
+        'Educate your entire team on how LFS works to prevent accidental commits of large files.'
+    ];
+
+    const commonMistakes = [
+        'Forgetting to run `git lfs install` on a new machine, causing LFS to not work correctly.',
+        'Committing a large file first, and *then* trying to track it. This requires rewriting history to fix.',
+        'Not committing the `.gitattributes` file, leading to inconsistent tracking across the team.',
+        'Tracking file types that change often but are not necessarily large, adding unnecessary LFS overhead.',
+        'Ignoring storage and bandwidth quotas on your Git host, which can lead to billing issues.'
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                <span className="text-primary-600 dark:text-primary-400">Git Good Practices:</span> Avoiding Large Binary Files
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    One of the most important rules for maintaining a healthy and efficient Git repository is to avoid committing large binary files directly. Git is a version control system for source code, not a file storage service for large assets. Committing them leads to a bloated repository that becomes slow and difficult to work with for everyone.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold">Key Concept: </strong>
+                        The modern solution is **Git Large File Storage (LFS)**. Instead of storing large files in your repository, you store lightweight text *pointers*. The actual file data is stored on a dedicated server, keeping your repository small and fast.
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Why & How to Handle Large Files</h2>
+                    <div className="space-y-6">
+                        {problemsAndSolutions.map((item, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{item.title}</h3>
+                                {item.code && <CodeBlock code={item.code} language="bash" />}
+                                {item.list && (
+                                    <ul className="space-y-2 my-4 text-gray-700 dark:text-gray-300">
+                                        {item.list.map((listItem, i) => <li key={i} className="text-sm">{listItem}</li>)}
+                                    </ul>
+                                )}
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{item.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <div className="grid md:grid-cols-2 gap-6 mb-8">
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Best Practices</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {bestPractices.map((practice, index) => (
+                                <li key={`best-${index}`} className="text-sm">{practice}</li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Common Mistakes</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {commonMistakes.map((mistake, index) => (
+                                <li key={`mistake-${index}`} className="text-sm">{mistake}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+
+                <div className="mt-8 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <h3 className="text-lg font-semibold text-primary-600 dark:text-primary-400 mb-2">What If I Already Committed a Large File?</h3>
+                    <p className="text-gray-700 dark:text-gray-300 mb-4">
+                        If a large file is already in your commit history, tracking it with LFS won't fix the problem. You must rewrite the repository's history to remove the file. This is an advanced and potentially destructive operation. Tools like `git lfs migrate` are designed for this.
+                    </p>
+                    <CodeBlock
+                        code={`# This is an advanced command that REWRITES history.
+# Always back up your repository before running it.
+
+# Example: Convert all existing .mp4 files in your history to LFS pointers
+git lfs migrate import --include="*.mp4" --everything`}
+                        language="bash"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default AvoidingLargeBinaries;

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/BestPractices/BranchNamingConventions.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/BestPractices/BranchNamingConventions.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const BranchNamingConventions = () => {
+    const conventionExamples = [
+        {
+            category: 'Feature Branches',
+            prefix: 'feature/',
+            description: 'Used for developing new features. The name should clearly describe the feature being added.',
+            examples: `
+# Good Examples
+feature/user-authentication
+feature/add-dark-mode-toggle
+feature/PROJ-123-implement-search-api
+`
+        },
+        {
+            category: 'Bugfix Branches',
+            prefix: 'bugfix/ or fix/',
+            description: 'Used for fixing bugs. It\'s helpful to include the issue or ticket number if you use a tracking system.',
+            examples: `
+# Good Examples
+fix/login-button-not-working
+bugfix/TICKET-451-fix-user-avatar-display
+fix/PROJ-245-resolve-api-timeout
+`
+        },
+        {
+            category: 'Release Branches',
+            prefix: 'release/',
+            description: 'Used to prepare for a new production release. They allow for last-minute bug fixes and preparation.',
+            examples: `
+# Good Examples
+release/v1.2.0
+release/v2.0.0-beta
+`
+        },
+        {
+            category: 'Hotfix Branches',
+            prefix: 'hotfix/',
+            description: 'Used for critical, urgent fixes to the production version. These branch off from your main production branch.',
+            examples: `
+# Good Examples
+hotfix/urgent-security-vulnerability
+hotfix/v1.1.1-critical-db-connection-fix
+`
+        }
+    ];
+
+    const bestPractices = [
+        'Be descriptive but concise. The name should communicate intent.',
+        'Use hyphens `-` to separate words, not underscores `_` or camelCase.',
+        'Start with a category prefix like `feature/` or `fix/` for organization.',
+        'Include a ticket/issue ID if your team uses a project management tool (e.g., `feature/PROJ-123-name`).',
+        'Use all lowercase letters to avoid case-sensitivity issues across different operating systems.',
+        'Avoid using personal names in branches (e.g., `johns-feature`).'
+    ];
+
+    const commonMistakes = [
+        'Vague or generic names like `dev`, `changes`, `my-branch`, or `bug_fix`.',
+        'Inconsistent naming schemes within the same project.',
+        'Making branch names excessively long and difficult to type or read.',
+        'Using special characters or spaces that can cause issues with shell commands.',
+        'Forgetting to delete branches after they have been merged, leading to clutter.'
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                <span className="text-primary-600 dark:text-primary-400">Git</span> Good Practices: Branch Naming
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    A consistent branch naming convention is a simple yet powerful tool for improving a project's clarity and organization. Well-named branches make it easier for team members to understand what work is in progress, streamline code reviews, and simplify the project's history. It's a form of communication that costs little but pays great dividends.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold">Key Concept: </strong>
+                        Treat branch names as a crucial part of your project's documentation. A good name instantly tells a story about its purpose, making your Git history transparent and easy to navigate.
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Common Naming Patterns</h2>
+                    <div className="space-y-6">
+                        {conventionExamples.map((conv, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">
+                                    {conv.category} (<code className="bg-gray-100 dark:bg-gray-800 px-1 rounded text-sm">{conv.prefix}</code>)
+                                </h3>
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mb-3">{conv.description}</p>
+                                <CodeBlock code={conv.examples} language="bash" />
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <div className="grid md:grid-cols-2 gap-6 mb-8">
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Best Practices</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {bestPractices.map((practice, index) => (
+                                <li key={`best-${index}`} className="text-sm">{practice}</li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Common Mistakes</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {commonMistakes.map((mistake, index) => (
+                                <li key={`mistake-${index}`} className="text-sm">{mistake}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+
+                <div className="mt-8 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <h3 className="text-lg font-semibold text-primary-600 dark:text-primary-400 mb-2">A Clean Branch List</h3>
+                    <p className="text-gray-700 dark:text-gray-300 mb-4">
+                        When your team follows a convention, the output of `git branch` becomes a clear, at-a-glance summary of all ongoing work.
+                    </p>
+                    <CodeBlock
+                        code={`$ git branch
+
+* feature/PROJ-488-user-profile-page
+  fix/PROJ-480-api-rate-limit
+  hotfix/v2.1.1-fix-critical-login-bug
+  main
+  release/v2.2.0`}
+                        language="bash"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default BranchNamingConventions;

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/BestPractices/GoodCommitMessages.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/BestPractices/GoodCommitMessages.jsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const GoodCommitMessages = () => {
+    const rules = [
+        {
+            rule: '1. Separate subject from body with a blank line',
+            explanation: 'Tools like `git log` and `git rebase` use this separation to format output. The subject is the summary, the body is the detail.'
+        },
+        {
+            rule: '2. Limit the subject line to 50 characters',
+            explanation: 'This keeps commit summaries concise and readable in various Git tools and on platforms like GitHub, which often truncates longer subjects.'
+        },
+        {
+            rule: '3. Capitalize the subject line',
+            explanation: 'This is a stylistic convention that makes the subject line read like a standard title or sentence heading.'
+        },
+        {
+            rule: '4. Do not end the subject line with a period',
+            explanation: 'The subject line is treated as a title, and titles typically do not end with a period. It also saves precious characters.'
+        },
+        {
+            rule: '5. Use the imperative mood in the subject line',
+            explanation: 'Write the subject as if you are giving a command (e.g., "Fix bug," not "Fixed bug" or "Fixes bug"). This matches Git\'s own style for automatically generated messages (e.g., "Merge branch...").'
+        },
+        {
+            rule: '6. Wrap the body at 72 characters',
+            explanation: 'This ensures that the commit message body is easy to read in terminals and other interfaces without forcing awkward line wraps.'
+        },
+        {
+            rule: '7. Use the body to explain what and why vs. how',
+            explanation: 'The code itself shows *how* the change was made. The commit message body should provide the context: *What* was the problem, and *why* is this the right solution?'
+        }
+    ];
+
+    const examples = [
+        {
+            title: 'Fixing a Bug',
+            bad: 'Fixed the login issue',
+            good: `Fix: Correct redirect loop on login page
+
+The previous logic did not handle cases where the user was
+already authenticated but accessed the login page directly,
+causing an infinite redirect.
+
+This change introduces a check at the top of the component to
+redirect authenticated users to the dashboard immediately.
+
+Resolves: #431`
+        },
+        {
+            title: 'Adding a Feature',
+            bad: 'added user export',
+            good: `Feat: Add CSV export for user data
+
+Implement a new endpoint /api/users/export that allows admins
+to download a CSV file of all users in the system.
+
+The "Export to CSV" button is now available on the main
+user management dashboard.`
+        },
+        {
+            title: 'Improving Performance',
+            bad: 'made things faster',
+            good: `Perf: Optimize image loading with lazy loading
+
+Refactor the main image component to use the Intersection
+Observer API. Images outside the viewport are no longer loaded
+on initial page render, significantly improving the Largest
+Contentful Paint (LCP) score.`
+        }
+    ];
+
+    const bestPractices = [
+        'Keep commits small and focused on a single logical change.',
+        'Proofread your messages before committing.',
+        'If your commit addresses an issue, reference it in the body or footer (e.g., `Fixes #123`).',
+        'Follow your team\'s established conventions for commit messages.',
+        'A good commit message provides context that the code alone cannot.'
+    ];
+
+    const commonMistakes = [
+        'Writing vague messages like "Fixes" or "Changes".',
+        'Putting multiple unrelated changes into a single commit.',
+        'Explaining *how* the code works instead of *why* the change was necessary.',
+        'Writing long, rambling subject lines that get cut off.',
+        'Ignoring established conventions like the imperative mood.'
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                Writing <span className="text-primary-600 dark:text-primary-400">Good</span> Commit Messages
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    A well-crafted Git commit message is a form of communication. It tells a story of your project's history, making it easier for you and your team to understand why a change was made, debug issues, and collaborate effectively. Adopting a clear and consistent style is one of the hallmarks of a professional developer.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold">Key Insight: </strong>
+                        Treat your commit messages as documentation for the future. Your primary audience is your future self and your teammates who need to understand the "why" behind a change, not just the "what."
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">The 7 Rules of a Great Commit Message</h2>
+                    <div className="space-y-4">
+                        {rules.map((item, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-4 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white">{item.rule}</h3>
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-1">{item.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Good vs. Bad Examples</h2>
+                    <div className="space-y-6">
+                        {examples.map((example, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{example.title}</h3>
+                                <div className="grid md:grid-cols-2 gap-4">
+                                    <div>
+                                        <h4 className="font-semibold text-red-500 dark:text-red-400 mb-2">Bad 👎</h4>
+                                        <CodeBlock code={example.bad} language="bash" />
+                                    </div>
+                                    <div>
+                                        <h4 className="font-semibold text-green-500 dark:text-green-400 mb-2">Good 👍</h4>
+                                        <CodeBlock code={example.good} language="bash" />
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <div className="grid md:grid-cols-2 gap-6 mb-8">
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Best Practices</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {bestPractices.map((practice, index) => (
+                                <li key={`best-${index}`} className="text-sm">{practice}</li>
+                            ))}
+                        </ul>
+                    </div>
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Common Mistakes</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {commonMistakes.map((mistake, index) => (
+                                <li key={`mistake-${index}`} className="text-sm">{mistake}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+
+                <div className="mt-8 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <h3 className="text-lg font-semibold text-primary-600 dark:text-primary-400 mb-2">Pro Tip: Use Conventional Commits</h3>
+                    <p className="text-gray-700 dark:text-gray-300 mb-4">
+                        For a more structured approach, consider the <a href="https://www.conventionalcommits.org/" target="_blank" rel="noopener noreferrer" className="text-primary-500 hover:underline">Conventional Commits</a> specification. It provides a lightweight convention on top of commit messages, making them easier to automate and understand.
+                    </p>
+                    <CodeBlock
+                        code={`<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+
+# Example:
+# feat(api): send email to user on registration
+#
+# Adds a new transactional email triggered after a new user
+# successfully completes the signup flow.
+#
+# Closes: T-452`}
+                        language="bash"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default GoodCommitMessages;

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/BestPractices/KeepingReposClean.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/BestPractices/KeepingReposClean.jsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const KeepingReposClean = () => {
+    const corePractices = [
+        {
+            title: 'Mastering the `.gitignore` File',
+            code: `# A sample .gitignore for a Node.js project
+
+# Dependencies
+/node_modules
+
+# Build output
+/build
+/dist
+
+# Log files
+*.log
+npm-debug.log*
+
+# Environment variables
+.env
+.env.local
+
+# OS-specific files
+.DS_Store
+Thumbs.db`,
+            explanation: 'The `.gitignore` file is your first and most important tool. It prevents unwanted files like dependencies, logs, build artifacts, and secrets from ever being tracked by Git, keeping your repository lean and focused on source code.'
+        },
+        {
+            title: 'Writing Atomic and Descriptive Commits',
+            code: `# BAD ❌
+git commit -m "stuff"
+git commit -m "fix bug and add feature and update docs"
+
+# GOOD ✅
+git commit -m "Fix: Resolve user login authentication error"
+git commit -m "Feat: Add user profile page with avatar upload"
+git commit -m "Docs: Update installation guide for v2.0"`,
+            explanation: 'An atomic commit contains a single, complete logical change. This makes your history easy to read, understand, and debug. Use a consistent format (e.g., Conventional Commits) for your messages.'
+        }
+    ];
+
+    const historyManagement = [
+        {
+            title: 'Pruning Stale Branches',
+            code: `# Switch to your main branch and pull the latest changes
+git checkout main
+git pull origin main
+
+# Delete a local branch that has been merged
+git branch -d feature/user-login
+
+# Delete a remote branch after it has been merged
+git push origin --delete feature/user-login`,
+            explanation: 'Repositories can get cluttered with old branches. Regularly deleting branches after they have been merged into your main branch keeps your repository tidy and easy to navigate.'
+        },
+        {
+            title: 'Using Interactive Rebase for Cleanup',
+            code: `# Before merging, clean up the last 3 commits on your feature branch
+git rebase -i HEAD~3
+
+# This opens an editor where you can 'squash' or 'fixup'
+# commits to combine them into a single, clean commit.
+
+# pick 1a2b3c4 Feat: Add basic form structure
+# squash 4d5e6f7 Feat: Add form validation
+# squash 8g9h0i1 Fix: Correct typo in form label`,
+            explanation: 'Interactive rebase is a powerful tool for tidying up your commit history on a feature branch *before* you merge it. You can reword, reorder, and combine commits to present a clean and logical history.'
+        }
+    ];
+
+    const dos = [
+        'Use a comprehensive `.gitignore` from the very beginning of a project.',
+        'Write commit messages in the imperative mood (e.g., "Add feature" not "Added feature").',
+        'Keep commits small and focused on a single logical change.',
+        'Delete local and remote branches after they are successfully merged.',
+        'Use tools like Git LFS (Large File Storage) for binary files like images, videos, or datasets.'
+    ];
+
+    const donts = [
+        'Never commit secrets, API keys, or other sensitive credentials.',
+        'Don\'t commit generated code, build artifacts, or package dependencies.',
+        'Avoid vague commit messages like "WIP", "fixes", or "changes".',
+        'Don\'t force push to shared branches (`main`, `develop`) as it rewrites history.',
+        'Avoid making a single, massive commit for an entire feature.'
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                <span className="text-primary-600 dark:text-primary-400">Git Good Practices:</span> Keeping Repositories Clean
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    A Git repository is more than just a code backup—it’s a living document that tells the story of your project. A clean, well-maintained repository is easier to navigate, simpler to debug, and much more welcoming for collaborators. Adopting a few key habits can significantly improve the quality of your project's history.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold">Key Concept: </strong>
+                        Treat your repository's history with the same care as your code. A clean history provides context and clarity, making the project more sustainable and professional in the long run.
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Core Cleanup Practices</h2>
+                    <div className="space-y-6">
+                        {corePractices.map((item, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{item.title}</h3>
+                                <CodeBlock code={item.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{item.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Managing History & Branches</h2>
+                    <div className="space-y-6">
+                        {historyManagement.map((item, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{item.title}</h3>
+                                <CodeBlock code={item.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{item.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <div className="grid md:grid-cols-2 gap-6 mb-8">
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Do's</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {dos.map((item, index) => (
+                                <li key={`do-${index}`} className="text-sm">{item}</li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Don'ts</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {donts.map((item, index) => (
+                                <li key={`dont-${index}`} className="text-sm">{item}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    );
+};
+
+export default KeepingReposClean;

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/GitStashAndTag/GitStash.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/GitStashAndTag/GitStash.jsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const GitStash = () => {
+    const stashCommands = [
+        {
+            title: 'Saving Changes: git stash save',
+            code: `# Stash your current changes
+git stash save "WIP: working on new feature X"
+
+# A shorter alias also works
+git stash "WIP: new feature"
+git stash # a default message will be generated`,
+            explanation: 'This command takes your uncommitted changes (both staged and unstaged), saves them on a stack for later use, and then reverts your working directory to match the last commit (HEAD).'
+        },
+        {
+            title: 'Listing Stashes: git stash list',
+            code: `git stash list
+
+# Output will look like this:
+# stash@{0}: WIP on main: 67a4e21 Add new feature
+# stash@{1}: On feature-branch: WIP: updating login form`,
+            explanation: 'Displays all the stashed changesets you have saved. Each stash is given an index, with stash@{0} being the most recent.'
+        },
+        {
+            title: 'Applying Stashes: git stash pop',
+            code: `# Apply the most recent stash and remove it from the list
+git stash pop
+
+# Apply a specific stash (e.g., the second one)
+git stash pop stash@{1}`,
+            explanation: 'Applies the changes from a stash to your current working directory and removes that stash from the stack. This is the most common way to retrieve stashed work.'
+        },
+        {
+            title: 'Applying without Deleting: git stash apply',
+            code: `# Apply the most recent stash but keep it in the list
+git stash apply
+
+# Apply a specific stash
+git stash apply stash@{1}`,
+            explanation: 'Works just like `git stash pop`, but it does *not* remove the stash from the stack. Useful if you want to apply the same changes to multiple branches.'
+        },
+        {
+            title: 'Deleting Stashes: git stash drop',
+            code: `# Drop the most recent stash
+git stash drop
+
+# Drop a specific stash
+git stash drop stash@{1}
+
+# Clear all stashes
+git stash clear`,
+            explanation: 'Removes a specific stash from the stack without applying it. Be careful, as this is a destructive action.'
+        }
+    ];
+
+    const bestPractices = [
+        'Always provide a descriptive message with `git stash save "message"` to remember what the stash contains.',
+        'Stash changes before pulling from the remote to avoid potential conflicts with your local work-in-progress.',
+        'Only stash work that is related. If you have multiple unrelated changes, make separate commits or stashes.',
+        'Before using `git stash pop`, ensure you are on the same branch where you created the stash to avoid confusion.',
+        'Regularly clean up old stashes using `git stash drop` or `git stash clear` to keep your stash list manageable.'
+    ];
+
+    const commonMistakes = [
+        'Forgetting which branch a stash was created on, leading to applying it in the wrong context.',
+        'Using `git stash` to avoid committing. If the work is significant, a feature branch with regular commits is better.',
+        'Letting the stash list grow too large, making it difficult to find the changes you need.',
+        'Accidentally dropping the wrong stash with `git stash drop` because the indices shift when you pop or drop.',
+        'Running into conflicts when popping a stash. You must resolve these conflicts manually, just like a merge conflict.'
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                <span className="text-primary-600 dark:text-primary-400">Git Stash:</span> Temporarily Shelving Changes
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    Ever been in the middle of coding a feature when an urgent bug report comes in? You need to switch branches, but your work isn't ready to be committed. This is the perfect scenario for `git stash`. It allows you to save your dirty working directory and switch contexts cleanly.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold">Key Concept: </strong>
+                        Git stash saves your uncommitted changes (both staged and unstaged) on a stack, allowing you to revert to a clean working directory. You can then re-apply these changes later using `git stash pop` or `git stash apply`.
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Core Stash Commands</h2>
+                    <div className="space-y-6">
+                        {stashCommands.map((command, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{command.title}</h3>
+                                <CodeBlock code={command.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{command.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">A Typical Workflow</h2>
+                     <div className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                        <ol className="list-decimal pl-6 space-y-4 text-gray-700 dark:text-gray-300">
+                            <li>
+                                <strong>You're working on a feature and have uncommitted changes.</strong>
+                                <CodeBlock code={`# You have edited file1.js and file2.js
+git status
+# On branch feature/new-design
+# Changes not staged for commit:
+#   (use "git add <file>..." to update what will be committed)
+#   (use "git restore <file>..." to discard changes in working directory)
+#	modified:   file1.js
+#	modified:   file2.js`} language="bash" />
+                            </li>
+                            <li>
+                                <strong>An urgent task requires you to switch branches. You stash your work.</strong>
+                                <CodeBlock code={`git stash save "WIP: new design form validation"`} language="bash" />
+                                <p className="text-sm mt-1">Your working directory is now clean, as if you hadn't made any changes.</p>
+                            </li>
+                            <li>
+                                <strong>You switch branches, fix the bug, commit, and switch back.</strong>
+                                 <CodeBlock code={`git checkout main
+# ...fix the bug...
+git add .
+git commit -m "Fix: critical login bug"
+git checkout feature/new-design`} language="bash" />
+                            </li>
+                            <li>
+                                <strong>Now back on your feature branch, you retrieve your stashed work.</strong>
+                                 <CodeBlock code={`git stash pop`} language="bash" />
+                                <p className="text-sm mt-1">Your changes to `file1.js` and `file2.js` are back, and you can continue where you left off. The stash is automatically removed from the list.</p>
+                            </li>
+                        </ol>
+                    </div>
+                </section>
+
+                <div className="grid md:grid-cols-2 gap-6 mb-8">
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Best Practices</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {bestPractices.map((practice, index) => (
+                                <li key={`best-${index}`} className="text-sm">{practice}</li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Common Mistakes</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {commonMistakes.map((mistake, index) => (
+                                <li key={`mistake-${index}`} className="text-sm">{mistake}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default GitStash;

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/GitStashAndTag/GitStashList.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/GitStashAndTag/GitStashList.jsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const GitStashList = () => {
+    const examples = [
+        {
+            title: 'Basic `git stash list`',
+            code: `# Save some changes to the stash
+git stash
+
+# View the list of stashes
+git stash list
+
+# --- Sample Output ---
+# stash@{0}: WIP on main: 5d8f3b4 Add user authentication
+# stash@{1}: WIP on feature/new-ui: 3a2c1d0 Update component styles`,
+            explanation: 'The default command shows all stashes in a LIFO (Last-In, First-Out) order. `stash@{0}` is always the most recent stash.'
+        },
+        {
+            title: 'Stashing with a Message',
+            code: `# Stash changes with a descriptive message
+git stash save "Working on user profile validation"
+
+# The list is now much clearer
+git stash list
+
+# --- Sample Output ---
+# stash@{0}: On main: Working on user profile validation
+# stash@{1}: WIP on main: 5d8f3b4 Add user authentication`,
+            explanation: 'Using `git stash save "message"` (or `git stash push -m "message"`) is highly recommended for identifying stashes later.'
+        },
+        {
+            title: 'Inspecting a Stash',
+            code: `# Show a summary of changes for the latest stash
+git stash show
+
+# Show a full diff (patch) for a specific stash
+git stash show -p stash@{1}
+
+# --- Sample Output for "show -p" ---
+# diff --git a/src/App.js b/src/App.js
+# index 9e8d7d7..6e8b4e2 100644
+# --- a/src/App.js
+# +++ b/src/App.js
+# @@ -1,5 +1,6 @@
+#  function App() {
+# +  // My stashed change
+#    return <div>Hello</div>
+#  }`,
+            explanation: 'Use `git stash show` to quickly see which files were changed, and add the `-p` flag to inspect the exact code changes within a stash.'
+        },
+        {
+            title: 'Applying or Dropping a Stash',
+            code: `# View the list to find the stash you need
+git stash list
+# stash@{0}: On main: Working on user profile validation
+# stash@{1}: WIP on feature/new-ui: 3a2c1d0 Update component styles
+
+# Apply the changes from stash@{1} but keep it in the list
+git stash apply stash@{1}
+
+# Apply the changes and remove it from the list
+git stash pop stash@{1}
+
+# Delete a specific stash without applying it
+git stash drop stash@{1}`,
+            explanation: 'You can interact with any stash in the list, not just the most recent one, by providing its identifier.'
+        }
+    ];
+
+    const bestPractices = [
+        'Always use `git stash save "message"` to add a description.',
+        'Regularly clean up your stash list by dropping stashes you no longer need.',
+        'Use `git stash show -p` to verify the contents of a stash before applying it.',
+        'For larger, long-term work, prefer creating a new branch over keeping a stash for a long time.',
+        'A clean stash list is a happy stash list. Don\'t let it become a graveyard of forgotten code.'
+    ];
+
+    const commonMistakes = [
+        'Creating too many anonymous "WIP on..." stashes, making it impossible to find things.',
+        'Forgetting what a stash contains because it lacks a descriptive message.',
+        'Accidentally dropping the wrong stash.',
+        'Applying a stash to the wrong branch, which can lead to complex merge conflicts.',
+        'Using `git stash` as a long-term storage solution instead of committing to feature branches.'
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                <span className="text-primary-600 dark:text-primary-400">Git</span> Stash List
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    The `git stash` command is a powerful tool for temporarily shelving changes you've made to your working copy so you can work on something else. The `git stash list` command is your way to view and manage these shelved changes. Understanding how to read and interact with this list is key to using stashes effectively.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold">Key Concept: </strong>
+                        Think of `git stash list` as your clipboard history for uncommitted code. It shows you a chronological list of saved states, allowing you to pick, choose, and manage your work-in-progress without making premature commits.
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Basic Commands & Output</h2>
+                    <div className="space-y-6">
+                        {examples.slice(0, 2).map((example, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{example.title}</h3>
+                                <CodeBlock code={example.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{example.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Inspecting & Using Stashes</h2>
+                    <div className="space-y-6">
+                        {examples.slice(2).map((example, index) => (
+                            <div key={index + 2} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{example.title}</h3>
+                                <CodeBlock code={example.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{example.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <div className="grid md:grid-cols-2 gap-6 mb-8">
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Best Practices</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {bestPractices.map((practice, index) => (
+                                <li key={`best-${index}`} className="text-sm">{practice}</li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Common Mistakes</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {commonMistakes.map((mistake, index) => (
+                                <li key={`mistake-${index}`} className="text-sm">{mistake}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    );
+};
+
+export default GitStashList;

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/GitStashAndTag/GitTagging.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/GitStashAndTag/GitTagging.jsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const GitTagging = () => {
+    const tagTypes = [
+        {
+            title: 'Lightweight Tags',
+            code: `# Create a lightweight tag at the current commit
+git tag v1.0.0-light
+
+# This creates a new tag but stores no extra information`,
+            explanation: 'A lightweight tag is just a pointer to a specific commit. It\'s like a branch that doesn’t move. It contains no extra information, such as who created it or when.'
+        },
+        {
+            title: 'Annotated Tags',
+            code: `# Create an annotated tag with a message
+git tag -a v1.0.0 -m "Release of version 1.0.0"
+
+# View the tag's data and the commit it points to
+git show v1.0.0
+
+# --- Sample Output for "show" ---
+# tag v1.0.0
+# Tagger: Your Name <your.email@example.com>
+# Date:   Fri Oct 3 20:22:01 2025 +0530
+#
+# Release of version 1.0.0
+#
+# commit 5d8f3b4a2b7c...
+# Author: Your Name <your.email@example.com>
+# Date:   Thu Oct 2 11:30:00 2025 +0530
+#
+#    Add user authentication`,
+            explanation: 'Annotated tags are stored as full objects in the Git database. They include the tagger\'s name, email, date, and a message. They can also be signed with GPG. This is the recommended type for releases.'
+        }
+    ];
+
+    const practicalExamples = [
+        {
+            title: 'Listing and Filtering Tags',
+            code: `# List all tags in alphabetical order
+git tag
+
+# --- Sample Output ---
+# v0.9.0
+# v1.0.0
+# v1.0.0-light
+
+# Use a pattern to filter tags (e.g., all v1.* tags)
+git tag -l "v1.*"`,
+            explanation: 'You can easily list all your tags or filter for specific ones using a pattern.'
+        },
+        {
+            title: 'Tagging an Older Commit',
+            code: `# First, find the hash of the commit you want to tag
+git log --oneline
+# 9fceb02 Fix critical bug in API
+# 5d8f3b4 Add user authentication
+
+# Tag that specific commit using its hash
+git tag -a v0.9.1 9fceb02 -m "Tagging the critical bug fix as v0.9.1"`,
+            explanation: 'Tags don\'t have to point to the most recent commit. You can tag any commit in your history by providing its hash.'
+        }
+    ];
+
+    const bestPractices = [
+        'Prefer annotated tags (`-a`) over lightweight tags for any public or shared release.',
+        'Adopt a consistent versioning scheme, such as Semantic Versioning (e.g., `v1.2.3`).',
+        'Write clear, descriptive messages for your annotated tags summarizing the release.',
+        'Consider signing your tags (`-s`) for important releases to make them verifiable.',
+        'Tags are created locally; they are not pushed to the remote by default.'
+    ];
+
+    const commonMistakes = [
+        'Forgetting to push tags to the remote repository. A `git push` does not send them.',
+        'Using lightweight tags for official releases, thereby losing valuable metadata.',
+        'Making a typo in a tag name that has already been pushed to a remote.',
+        'Tagging the wrong commit and not realizing it until after the release.',
+        'Deleting a pushed tag locally (`git tag -d`) and forgetting to delete it on the remote.'
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                <span className="text-primary-600 dark:text-primary-400">Git</span> Tagging: Marking Milestones
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    In Git, a "tag" is a permanent pointer to a specific commit. It’s like a bookmark for a significant point in your project’s history, most commonly used to mark release points (e.g., `v1.0`, `v2.1`). Unlike branches, tags are not meant to move once created, providing a stable reference to a specific version of your code.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold">Key Concept: </strong>
+                        Tags provide stable, human-readable names for specific commits. While a branch is a moving pointer, a tag is a fixed anchor, making it the industry standard for versioning and release management.
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Lightweight vs. Annotated Tags</h2>
+                    <div className="space-y-6">
+                        {tagTypes.map((tag, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{tag.title}</h3>
+                                <CodeBlock code={tag.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{tag.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Practical Usage</h2>
+                    <div className="space-y-6">
+                        {practicalExamples.map((example, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">{example.title}</h3>
+                                <CodeBlock code={example.code} language="bash" />
+                                <p className="text-gray-700 dark:text-gray-300 text-sm mt-2">{example.explanation}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <div className="grid md:grid-cols-2 gap-6 mb-8">
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Best Practices</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {bestPractices.map((practice, index) => (
+                                <li key={`best-${index}`} className="text-sm">{practice}</li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Common Mistakes</h3>
+                        <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
+                            {commonMistakes.map((mistake, index) => (
+                                <li key={`mistake-${index}`} className="text-sm">{mistake}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+
+                <div className="mt-8 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <h3 className="text-lg font-semibold text-primary-600 dark:text-primary-400 mb-2">Sharing Tags with Others</h3>
+                    <p className="text-gray-700 dark:text-gray-300 mb-4">
+                        By default, `git push` will not transfer tags to the remote server. You must explicitly push tags to make them available to others.
+                    </p>
+                    <CodeBlock
+                        code={`# Push a single, specific tag to the 'origin' remote
+git push origin v1.0.0
+
+# Push all of your local tags to the 'origin' remote
+# (Use with caution, as this may push tags you didn't intend to share)
+git push origin --tags`}
+                        language="bash"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default GitTagging;

--- a/client/src/pages/Notes/GitVersionControl/GitTopics/GitStashAndTag/TagTypeComparison.jsx
+++ b/client/src/pages/Notes/GitVersionControl/GitTopics/GitStashAndTag/TagTypeComparison.jsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import CodeBlock from '../../../components/CodeBlock';
+
+const TagTypesComparison = () => {
+    const tagDetails = [
+        {
+            type: 'Lightweight Tags',
+            description: 'Think of a lightweight tag as a simple "sticky note" on a commit. It is a direct pointer to a commit hash and stores no other information. It\'s just a name for a commit.',
+            code: `# Create a lightweight tag
+git tag v1.2.0-lw
+
+# Showing the tag only displays the commit information
+git show v1.2.0-lw
+
+# --- Output ---
+# commit 9fceb02a33dcb...
+# Author: Your Name <your.email@example.com>
+# Date:   Thu Oct 2 11:30:00 2025 +0530
+#
+#    Fix critical bug in API`
+        },
+        {
+            type: 'Annotated Tags',
+            description: 'An annotated tag is like an "official plaque." It\'s a full Git object that contains its own metadata, including the tagger\'s name, email, date, and a specific tagging message, separate from the commit message.',
+            code: `# Create an annotated tag
+git tag -a v1.2.0 -m "Version 1.2.0 Release"
+
+# Showing the tag displays tag metadata first, then the commit
+git show v1.2.0
+
+# --- Output ---
+# tag v1.2.0
+# Tagger: Your Name <your.email@example.com>
+# Date:   Fri Oct 3 20:23:40 2025 +0530
+#
+# Version 1.2.0 Release
+#
+# commit 9fceb02a33dcb...`
+        }
+    ];
+
+    const comparison = [
+        {
+            aspect: 'Metadata',
+            lightweight: 'None. It\'s just a name for a commit.',
+            annotated: 'Stores tagger name, email, date, and a tagging message.'
+        },
+        {
+            aspect: 'Use Case',
+            lightweight: 'Private or temporary labels, personal bookmarks.',
+            annotated: 'Official releases, public milestones, shared tags.'
+        },
+        {
+            aspect: 'Creation Command',
+            lightweight: '`git tag <tag-name>`',
+            annotated: '`git tag -a <tag-name> -m "message"`'
+        },
+        {
+            aspect: 'GPG Signing',
+            lightweight: 'Cannot be signed.',
+            annotated: 'Can be signed using the `-s` flag for verification.'
+        },
+        {
+            aspect: 'Storage in Git',
+            lightweight: 'A file in `.git/refs/tags/` containing a commit hash.',
+            annotated: 'A full tag object in the Git database with its own hash.'
+        }
+    ];
+    
+    const whenToUse = [
+        {
+            type: 'Choose Lightweight When...',
+            reasons: [
+                'You need a temporary label for personal use.',
+                'You are creating a quick, disposable bookmark for a commit.',
+                'The context (who, when, why) of the tag is irrelevant.',
+                'You are the only person who will ever see or use the tag.'
+            ]
+        },
+        {
+            type: 'Choose Annotated When...',
+            reasons: [
+                'You are marking an official release (e.g., v1.0.0).',
+                'The tag needs to be shared with a team or the public.',
+                'You need to include details, like release notes, in the tag message.',
+                'The tag needs to be signed for security and verification.'
+            ]
+        }
+    ];
+
+    return (
+        <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-6">
+                <span className="text-primary-600 dark:text-primary-400">Git Tags:</span> Annotated vs. Lightweight
+            </h1>
+
+            <div className="prose max-w-none">
+                <p className="text-base text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">
+                    Git offers two types of tags, and understanding the difference is crucial for effective versioning and release management. While they both point to a specific commit, how they store information and their intended use cases are very different. Choosing the right one ensures your project history is both clear and professional.
+                </p>
+
+                <div className="mb-6 bg-white dark:bg-black p-4 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                    <p className="text-primary-500 dark:text-primary-400">
+                        <strong className="font-semibold">Key Insight: </strong>
+                        The fundamental difference is **metadata**. Annotated tags are rich objects with an author, date, and message, while lightweight tags are simple, nameless pointers. For any shared work, annotated is the way to go.
+                    </p>
+                </div>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">The Two Tag Types Explained</h2>
+                    <div className="grid md:grid-cols-2 gap-6">
+                        {tagDetails.map((tag, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                                <h3 className="text-xl font-semibold text-primary-600 dark:text-primary-400 mb-3">{tag.type}</h3>
+                                <p className="text-gray-700 dark:text-gray-300 mb-4 text-sm">{tag.description}</p>
+                                <CodeBlock code={tag.code} language="bash" />
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">Side-by-Side Comparison</h2>
+                    <div className="overflow-x-auto">
+                        <table className="min-w-full bg-white dark:bg-black rounded-lg overflow-hidden">
+                            <thead className="bg-gray-100 dark:bg-gray-800">
+                                <tr>
+                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Aspect</th>
+                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Lightweight Tag</th>
+                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Annotated Tag</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                                {comparison.map((item, index) => (
+                                    <tr key={index} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200">{item.aspect}</td>
+                                        <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">{item.lightweight}</td>
+                                        <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">{item.annotated}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <section className="mb-8">
+                    <h2 className="text-2xl font-semibold text-gray-800 dark:text-white mb-4">When to Use Each</h2>
+                    <div className="grid md:grid-cols-2 gap-6">
+                        {whenToUse.map((item, index) => (
+                            <div key={index} className="bg-white dark:bg-black p-6 rounded-md shadow-sm border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-gray-600 transition-colors">
+                                <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-3">{item.type}</h3>
+                                <ul className="space-y-2">
+                                    {item.reasons.map((reason, i) => (
+                                        <li key={i} className="flex items-start">
+                                            <span className="text-green-500 mr-2 mt-1">•</span>
+                                            <span className="text-gray-700 dark:text-gray-300 text-sm">{reason}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+            </div>
+        </div>
+    );
+};
+
+export default TagTypesComparison;


### PR DESCRIPTION
**Hi team 👋**

This PR introduces a new React component responsible for dynamically updating the page title according to the active Git topic or component displayed on the page. This improves user experience by providing context-aware titles that reflect the current content focus.

---

### 🔍 Problem Resolved

- Previous versions did not dynamically update the document’s page title based on the active Git topic, which can cause confusion or reduce usability especially when navigating multiple documentation pages.
- Adding this title manager enhances clarity and accessibility by making the page title relevant and descriptive.

---

### ✅ What’s Changed

- **Added:** A `PageTitleManager` React component that listens to active component/topic changes and updates the `document.title` accordingly.
- Used React context or hooks to propagate state about current active Git topic to this component.
- Provided a default fallback title and safeguards against empty or missing titles.
- Ensured compatibility with server-side rendering and client-side navigation to keep the title consistent with content.

---

### 📸 Screenshot

<img width="306" height="53" alt="image" src="https://github.com/user-attachments/assets/d6ae5907-2a67-4fab-a3dd-2013a876d00d" />
<img width="1216" height="264" alt="image" src="https://github.com/user-attachments/assets/e06f3cd0-c161-48ef-ad19-e063ff0d6f91" />


---

### 🎯 Result

- Users see meaningful page titles reflecting their current topic, enhancing navigation and bookmarking.
- Improves SEO and accessibility standards by keeping the document title synchronized with content.

---

### 🏷 Labels Requested

* `gssoc25`
* `frontend`
* `documentation`
* `level3`

---
