### PR TITLE
Fix: Prevent Service Worker from caching during local development

### DIFF
--- a/client/public/service-worker.js
+++ b/client/public/service-worker.js
@@ -2,131 +2,109 @@
 const CACHE_NAME = 'app-cache-v1';
 
 // Only cache essential files that definitely exist
-const urlsToCache = [
-  '/',
-  '/index.html',
-  // Remove specific file paths that might not exist
-  // Let the dynamic caching handle other assets
-];
+const urlsToCache = ['/', '/index.html'];
 
+// Disable SW entirely in development (localhost or 5173)
+if (
+  self.location.hostname === 'localhost' ||
+  self.location.port === '5173'
+) {
+  console.log('⚙️ Service Worker disabled in development (localhost:5173)');
+  self.addEventListener('install', (event) => self.skipWaiting());
+  self.addEventListener('activate', (event) => self.clients.claim());
+  // Stop here — don’t register fetch handlers or caching
+  return;
+}
+
+// Install
 self.addEventListener('install', (event) => {
   console.log('Service Worker installing');
-  
-  // Skip waiting - activate immediately
   self.skipWaiting();
-  
+
   event.waitUntil(
-    caches.open(CACHE_NAME)
+    caches
+      .open(CACHE_NAME)
       .then((cache) => {
         console.log('Opened cache');
-        
-        // Use a more robust caching approach
         return Promise.allSettled(
-          urlsToCache.map(url => {
-            return cache.add(url).catch(error => {
+          urlsToCache.map((url) =>
+            cache.add(url).catch((error) => {
               console.warn(`Failed to cache: ${url}`, error);
-              // Don't fail the entire installation if one file fails
               return null;
-            });
-          })
+            })
+          )
         );
       })
-      .then(results => {
-        const failed = results.filter(r => r.status === 'rejected');
+      .then((results) => {
+        const failed = results.filter((r) => r.status === 'rejected');
         if (failed.length > 0) {
           console.warn(`${failed.length} files failed to cache`);
         } else {
           console.log('All files cached successfully');
         }
       })
-      .catch(error => {
-        console.log('Cache installation error:', error);
-        // Don't fail the installation - continue anyway
+      .catch((error) => {
+        console.error('Cache installation error:', error);
       })
   );
 });
 
+// Fetch (Cache-first, then network fallback)
 self.addEventListener('fetch', (event) => {
-  // Skip non-GET requests
-  if (event.request.method !== 'GET') {
-    return;
-  }
-
-  // Skip chrome-extension requests
-  if (event.request.url.startsWith('chrome-extension://')) {
-    return;
-  }
-
-  // Skip non-HTTP/HTTPS requests
-  if (!event.request.url.startsWith('http')) {
-    return;
-  }
+  if (event.request.method !== 'GET') return;
+  if (event.request.url.startsWith('chrome-extension://')) return;
+  if (!event.request.url.startsWith('http')) return;
 
   event.respondWith(
-    caches.match(event.request)
-      .then((response) => {
-        // Return cached version if found
-        if (response) {
-          return response;
-        }
+    caches.match(event.request).then((response) => {
+      if (response) return response;
 
-        // Otherwise fetch from network
-        return fetch(event.request)
-          .then((response) => {
-            // Check if valid response
-            if (!response || response.status !== 200 || response.type !== 'basic') {
-              return response;
-            }
-
-            // Clone the response
-            const responseToCache = response.clone();
-
-            // Cache the successful response
-            caches.open(CACHE_NAME)
-              .then((cache) => {
-                // Only cache same-origin requests
-                if (event.request.url.startsWith(self.location.origin)) {
-                  cache.put(event.request, responseToCache)
-                    .catch(error => {
-                      console.warn('Failed to cache response:', error);
-                    });
-                }
-              });
-
+      return fetch(event.request)
+        .then((response) => {
+          if (!response || response.status !== 200 || response.type !== 'basic') {
             return response;
-          })
-          .catch(() => {
-            // Return a fallback for failed requests
-            // You could return an offline page here
-            return new Response('You are offline', {
-              status: 503,
-              statusText: 'Service Unavailable',
-              headers: new Headers({
-                'Content-Type': 'text/plain'
-              })
-            });
+          }
+
+          const responseToCache = response.clone();
+          caches.open(CACHE_NAME).then((cache) => {
+            if (event.request.url.startsWith(self.location.origin)) {
+              cache.put(event.request, responseToCache).catch((error) => {
+                console.warn('Failed to cache response:', error);
+              });
+            }
           });
-      })
+
+          return response;
+        })
+        .catch(() => {
+          return new Response('You are offline', {
+            status: 503,
+            statusText: 'Service Unavailable',
+            headers: new Headers({
+              'Content-Type': 'text/plain',
+            }),
+          });
+        });
+    })
   );
 });
 
+// Activate
 self.addEventListener('activate', (event) => {
   console.log('Service Worker activating');
-  
-  // Take control immediately
   event.waitUntil(
     Promise.all([
       self.clients.claim(),
-      caches.keys().then((cacheNames) => {
-        return Promise.all(
+      caches.keys().then((cacheNames) =>
+        Promise.all(
           cacheNames.map((cacheName) => {
             if (cacheName !== CACHE_NAME) {
               console.log('Deleting old cache:', cacheName);
               return caches.delete(cacheName);
             }
           })
-        );
-      })
+        )
+      ),
     ])
   );
 });

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -42,20 +42,36 @@ ReactDOM.createRoot(document.getElementById("root")).render(
 
 // ✅ Register service worker for PWA support
 if ("serviceWorker" in navigator) {
-  window.addEventListener("load", () => {
-    // Use the correct base path based on environment
-    const swUrl = `${window.location.origin}/service-worker.js`;
-    navigator.serviceWorker
-      .register(swUrl)
-      .then((registration) => {
-        console.log("Service Worker registered with scope:", registration.scope);
-      })
-      .catch((error) => {
-        console.error("Service Worker registration failed:", error);
-        // Fallback to relative path
-        navigator.serviceWorker.register('./service-worker.js').then(fallbackRegistration => {
-          console.log("Service Worker registered with fallback:", fallbackRegistration.scope);
+  // Only register in production (Netlify, etc.)
+  if (import.meta.env.MODE === "production") {
+    window.addEventListener("load", () => {
+      const swUrl = `${window.location.origin}/service-worker.js`;
+      navigator.serviceWorker
+        .register(swUrl)
+        .then((registration) => {
+          console.log("✅ Service Worker registered with scope:", registration.scope);
+        })
+        .catch((error) => {
+          console.error("❌ Service Worker registration failed:", error);
+          // Optional fallback
+          navigator.serviceWorker
+            .register("./service-worker.js")
+            .then((fallbackRegistration) => {
+              console.log("✅ Fallback SW registered with scope:", fallbackRegistration.scope);
+            })
+            .catch((err) => console.error("Fallback SW failed:", err));
         });
-      });
-  });
+    });
+  } else {
+    // 🚫 Disable SW & clear caches in development (e.g., localhost:5173)
+    navigator.serviceWorker.getRegistrations().then((regs) => {
+      for (const reg of regs) {
+        reg.unregister();
+      }
+    });
+    caches.keys().then((keys) =>
+      Promise.all(keys.map((key) => caches.delete(key)))
+    );
+    console.log("⚙️ Service Worker disabled in development (localhost:5173)");
+  }
 }


### PR DESCRIPTION
### 🧩 Related Issue
Fixes #568

---

### ⚠️ Problem
When running the project locally (`localhost:5173`), the `service-worker.js` file was still being registered and caching previous project builds.  
This caused:
- The app UI to appear briefly and then disappear (blank screen).
- Old cached versions of the project to load even after stopping or changing the project on the same port.

The issue happened because the service worker kept intercepting requests and serving outdated cached files instead of fresh ones from the dev server.

---

### 🛠️ Changes Made
1. **Updated `service-worker.js`**
   - Added logic to skip caching and fetch interception during local development.

2. **Updated `main.jsx`**
   - Added a check to register the service worker **only in production** builds (e.g., on Netlify).
   - This ensures the service worker doesn’t interfere when developing locally.

---

### ✅ Result
- The service worker will now only be active in production.
- Local development will always load the latest content without caching conflicts.
- The app works normally again on `localhost:5173`.

---

### 🧠 How to Test
1. Run the app locally using `npm run dev`.
2. Open the browser dev tools → Application → Service Workers tab.
3. Confirm that no service worker is registered in local mode.
4. Deploy the app to Netlify (or run a production build) and verify that the service worker registers correctly there.

---

### 🌟 Summary
This PR fixes the caching conflict that caused the local UI to disappear.  
It ensures a smooth development experience and keeps PWA features functional only in production.
